### PR TITLE
[API] 작업물 목록 조회 리팩토링 및 스웨거 설정

### DIFF
--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -1,22 +1,103 @@
 import { Controller } from '../../types/express';
 import TranslationsService from './translations.service';
 
+/**
+ * @swagger
+ *  /api/challenges/{challengeId}/translations:
+ *   get:
+ *     summary: 챌린지에 속한 번역물 목록 조회
+ *     description: 특정 챌린지에 속한 번역물 목록을 추천수 순으로 정렬하여 조회합니다.페이지네이션을 지원합니다.
+ *     tags: [Translations]
+ *     parameters:
+ *       - in: path
+ *         name: challengeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 챌린지 ID
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *         description: 페이지 번호
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 5
+ *         description: 한 페이지당 항목 수
+ *     responses:
+ *       200:
+ *         description: 번역물 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 translations:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       title:
+ *                         type: string
+ *                       content:
+ *                         type: string
+ *                       userId:
+ *                         type: string
+ *                       challengeId:
+ *                         type: string
+ *                       likeCount:
+ *                         type: integer
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                       updatedAt:
+ *                         type: string
+ *                         format: date-time
+ *                 totalCount:
+ *                   type: integer
+ *                   description: 전체 번역물 개수
+ *                 message:
+ *                   type: string
+ *                   example: 번역물
+ *       400:
+ *         description: 잘못된 요청
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Challenge ID is required
+ *       500:
+ *         description: 서버 오류
+ */
 const getTranslations: Controller = async (req, res, next) => {
   try {
     const { challengeId } = req.params;
     const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 5;
 
     if (!challengeId) {
-      return next({ statusCode: 400 });
+      return next({ statusCode: 400, message: 'Challenge ID is required' });
     }
 
     const { translations, totalCount } =
-      await TranslationsService.getTranslations(challengeId, page);
+      await TranslationsService.getTranslations({
+        challengeId,
+        page,
+        limit,
+      });
 
     res.status(200).json({
-      success: true,
-      data: translations,
+      translations,
       totalCount,
+      message: '번역물',
     });
   } catch (err) {
     next(err);

--- a/src/domains/translations/translations.service.ts
+++ b/src/domains/translations/translations.service.ts
@@ -1,10 +1,16 @@
 import prisma from '../../prismaClient';
 
-const getTranslations = async (
-  challengeId: string,
-  page: number = 1,
-  pageSize: number = 5
-) => {
+interface GetTranslationsParams {
+  challengeId: string;
+  page: number;
+  limit: number;
+}
+
+const getTranslations = async ({
+  challengeId,
+  page,
+  limit,
+}: GetTranslationsParams) => {
   const [translations, totalCount] = await Promise.all([
     prisma.translation.findMany({
       where: {
@@ -14,8 +20,8 @@ const getTranslations = async (
       orderBy: {
         likeCount: 'desc',
       },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
+      skip: (page - 1) * limit,
+      take: limit,
     }),
     prisma.translation.count({
       where: {

--- a/src/domains/translations/translations.service.ts
+++ b/src/domains/translations/translations.service.ts
@@ -11,6 +11,15 @@ const getTranslations = async ({
   page,
   limit,
 }: GetTranslationsParams) => {
+  // 챌린지 존재 여부 확인
+  const challengeExists = await prisma.challenge.findUnique({
+    where: { id: challengeId },
+    select: { id: true },
+  });
+
+  if (!challengeExists) {
+    throw new Error('Challenge not found');
+  }
   const [translations, totalCount] = await Promise.all([
     prisma.translation.findMany({
       where: {


### PR DESCRIPTION
## 📌 개요

- 특정 챌린지의 번역 작업물 목록 조회

## ✨ 주요 변경 사항

- 피드백 반영하여 코드 리팩토링하였습니다. (컨트롤러에서 prisma 직접 사용 X)
- 응답 구조 형식에 맞게 작업하였습니다. 

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 경로  GET /api/challenges/{challengeId}/translations
-  limit 쿼리 파라미터 추가하여 페이지당 항목 수 지정할 수 있게 하였습니다. 
- totalCount와 같이 페이지네이션에 이용하시면 됩니다. 

## 🔗 관련 이슈

#13 

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/b76cd8b9-4064-4c26-b470-731c781d8a3b)

![image](https://github.com/user-attachments/assets/1891e33f-3b60-4e63-a8d7-529a8cb84b3b)
