### PR TITLE
Feature: Request 인증 미들웨어 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "jsonwebtoken": "^9.0.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -2987,6 +2988,15 @@
       "optional": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "jsonwebtoken": "^9.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -1,13 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 import AuthService from './auth.service';
 import jwtUtils from '../../utils/jwt';
+import { LoginBodyDTO, SignUpBodyDTO } from './auth.types';
 
 /**
  * @swagger
  * /api/auth/signup:
  *   post:
  *     summary: 회원가입
- *     description: email, nickname, password를 입력받아 회원가입을 수행합니다.
+ *     description: email, nickName, password를 입력받아 회원가입을 수행합니다.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -60,18 +61,7 @@ import jwtUtils from '../../utils/jwt';
  *                   example: 이미 존재하고 있는 email 입니다.
  */
 const signup = async (req: Request, res: Response, next: NextFunction) => {
-  const { email, nickName, password } = req.body;
-
-  console.log(email, nickName, password);
-
-  // 유효성 검사
-  if (!email || !nickName || !password) {
-    next({
-      statusCode: 400,
-      message: 'email, nickname, password가 모두 있어야 햡니다.',
-    });
-    return;
-  }
+  const { email, nickName, password }: SignUpBodyDTO = req.body;
 
   try {
     const existedUser = await AuthService.checkEmail(email);
@@ -165,12 +155,7 @@ const signup = async (req: Request, res: Response, next: NextFunction) => {
  *                   example: 비밀번호가 일치하지 않습니다.
  */
 const login = async (req: Request, res: Response, next: NextFunction) => {
-  const { email, password } = req.body;
-
-  if (!email || !password) {
-    next({ statusCode: 400, message: 'email, password가 모두 있어야 합니다.' });
-    return;
-  }
+  const { email, password }: LoginBodyDTO = req.body;
 
   const existedUser = await AuthService.checkEmail(email);
 

--- a/src/domains/auth/auth.routes.ts
+++ b/src/domains/auth/auth.routes.ts
@@ -1,10 +1,33 @@
-import { Router } from 'express';
+import { NextFunction, Request, Response, Router } from 'express';
 import authController from './auth.controller';
+import { ZodSchema } from 'zod';
+import {
+  testBodySchema,
+  testParamsSchema,
+  testQueriesSchema,
+} from './auth.types';
+import { validateRequestData } from '../../middleware/validateRequestData';
 
 const router = Router();
 
 router.post('/signup', authController.signup); //회원가입
 router.post('/login', authController.login); //로그인
 router.post('/logout'); //로그아웃
+
+// TODO: 테스트 용 api, 삭제 예정
+router.post(
+  '/test/:id/:params2',
+  validateRequestData({
+    params: testParamsSchema,
+    query: testQueriesSchema,
+    body: testBodySchema,
+  }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    console.log(req.params);
+    console.log(req.query);
+    const { email, password } = req.body;
+    res.send('hello');
+  }
+);
 
 export default router;

--- a/src/domains/auth/auth.routes.ts
+++ b/src/domains/auth/auth.routes.ts
@@ -2,6 +2,8 @@ import { NextFunction, Request, Response, Router } from 'express';
 import authController from './auth.controller';
 import { ZodSchema } from 'zod';
 import {
+  LoginBodySchema,
+  SignUpBodySchema,
   testBodySchema,
   testParamsSchema,
   testQueriesSchema,
@@ -10,8 +12,18 @@ import { validateRequestData } from '../../middleware/validateRequestData';
 
 const router = Router();
 
-router.post('/signup', authController.signup); //회원가입
-router.post('/login', authController.login); //로그인
+router.post(
+  '/signup',
+  validateRequestData({ body: SignUpBodySchema }),
+  authController.signup
+); // 회원가입
+
+router.post(
+  '/login',
+  validateRequestData({ body: LoginBodySchema }),
+  authController.login
+); // 로그인
+
 router.post('/logout'); //로그아웃
 
 // TODO: 테스트 용 api, 삭제 예정

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -1,14 +1,9 @@
 import prisma from '../../prismaClient';
 import bcrpyt from 'bcrypt';
 import CustomError from '../../types/error';
+import { SignUpBodyDTO } from './auth.types';
 
-interface SignupDTO {
-  email: string;
-  nickName: string;
-  password: string;
-}
-
-const createUser = async (data: SignupDTO) => {
+const createUser = async (data: SignUpBodyDTO) => {
   const hashedPassword = await bcrpyt.hash(data.password, 10);
 
   try {

--- a/src/domains/auth/auth.types.ts
+++ b/src/domains/auth/auth.types.ts
@@ -1,0 +1,28 @@
+import z from 'zod';
+
+// TODO: 테스트용입니다. 나중에 삭제 예정입니다.
+export const testParamsSchema = z.object({
+  id: z.string().uuid({ message: 'id는 uuid 형식어아야 합니다.' }),
+});
+
+export const testQueriesSchema = z.object({
+  sort: z.enum(['desc', 'asc'], {
+    message: 'sort는 desc, asc 중 하나',
+  }),
+});
+
+export const testBodySchema = z.object({
+  email: z.string().email({ message: '이메일 형식을 지켜주세요.' }),
+  password: z.string().min(8, { message: '비번 8자리 이상' }),
+});
+
+export type testRequestParams = z.infer<typeof testParamsSchema>;
+export type testRequestQueries = z.infer<typeof testQueriesSchema>;
+export type testRequestBody = z.infer<typeof testBodySchema>;
+
+// 회원가입 API
+export const SignUpBodySchema = z.object({
+  email: z.string().email({ message: '이메일 형식을 지켜주세요.' }),
+  nickName: z.string(),
+  password: z.string().min(8, { message: '비밀번호는 8자리 이상' }),
+});

--- a/src/domains/auth/auth.types.ts
+++ b/src/domains/auth/auth.types.ts
@@ -26,3 +26,20 @@ export const SignUpBodySchema = z.object({
   nickName: z.string(),
   password: z.string().min(8, { message: '비밀번호는 8자리 이상' }),
 });
+
+export type SignUpBodyDTO = z.infer<typeof SignUpBodySchema>;
+
+// export interface SighUpResponseDTO {
+//     user: {
+//         email: string,
+//         nickName: string
+//     }
+// }
+
+// 로그인 API
+export const LoginBodySchema = z.object({
+  email: z.string().email({ message: '이메일 형식을 지켜주세요.' }),
+  password: z.string().min(8, { message: '비밀번호는 8자리 이상' }),
+});
+
+export type LoginBodyDTO = z.infer<typeof LoginBodySchema>;

--- a/src/middleware/validateRequestData.ts
+++ b/src/middleware/validateRequestData.ts
@@ -1,0 +1,47 @@
+import { ZodSchema } from 'zod';
+import { NextFunction, Request, Response } from 'express';
+
+type SchemaSet = {
+  body?: ZodSchema;
+  query?: ZodSchema;
+  params?: ZodSchema;
+};
+
+export const validateRequestData =
+  (schemas: SchemaSet) => (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Body 검증
+      if (schemas.body) {
+        const result = schemas.body.safeParse(req.body);
+        if (!result.success) {
+          next({ statusCode: 400, message: result.error.flatten() });
+          return;
+        }
+        req.body = result.data;
+      }
+
+      // Query 검증
+      if (schemas.query) {
+        const result = schemas.query.safeParse(req.query);
+        if (!result.success) {
+          next({ statusCode: 400, message: result.error.flatten() });
+          return;
+        }
+        req.query = result.data;
+      }
+
+      // Params 검증
+      if (schemas.params) {
+        const result = schemas.params.safeParse(req.params);
+        if (!result.success) {
+          next({ statusCode: 400, message: result.error.flatten() });
+          return;
+        }
+        req.params = result.data;
+      }
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };


### PR DESCRIPTION
## 📌 개요
Request에 params, query, body에 대한 유효성 검사 미들웨어 구현.

## ✨ 주요 변경 사항
- zod 패키지 추가
- `validateRequestData` 미들웨어 생성
- api/auth/test로 테스트 생성 -> 추후 삭제 예정

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

```ts
// 회원가입 API
export const SignUpBodySchema = z.object({
  email: z.string().email({ message: '이메일 형식을 지켜주세요.' }),
  nickName: z.string(),
  password: z.string().min(8, { message: '비밀번호는 8자리 이상' }),
});

export type SignUpBodyDTO = z.infer<typeof SignUpBodySchema>;
```
- request에 대한 유효성 검사하는 것 zod를 사용해서 구현
- 정의한 스키마를 이용해서 DTO 생성 가능(예시 `SignUpBodyDTO`)

## 🔗 관련 이슈
#30 
