### PR TITLE
[Feature] 챌린지 생성 API 구현

### DIFF
--- a/src/domains/challenges/challenges.controller.ts
+++ b/src/domains/challenges/challenges.controller.ts
@@ -1,9 +1,9 @@
 import ChallengesService from './challenges.service';
 import { isValidEnumValue } from '../../utils/isValidEnumValue';
 import { ApprovalStatus, DocumentType, FieldType } from '@prisma/client';
-import { GetController } from '../../types/express';
-import { isValidUUID } from '../../utils/isUUID';
-import { GetChallengeListQuery, GetChallengeListResponse, GetChallengeParam, GetChallengeResponse } from './challenges.type';
+import { GetController, PostController } from '../../types/express';
+import { GetChallengeListResponse, GetChallengeResponse, PostChallengeResponse } from './challenges.type';
+import { ChallengeRequestBody, ChallengeRequestParams, ChallengeRequestQueries } from './challenges.validation';
 
 /**
  * @swagger
@@ -113,13 +113,9 @@ import { GetChallengeListQuery, GetChallengeListResponse, GetChallengeParam, Get
  *       500:
  *         description: 서버 오류
  */
-const getChallenge: GetController<GetChallengeParam, never, GetChallengeResponse> = async (req, res, next) => {
+const getChallenge: GetController<ChallengeRequestParams, never, GetChallengeResponse> = async (req, res, next) => {
   try {
     const id = req.params.challengeId;
-    if (!isValidUUID(id)) {
-      next({ statusCode: 400 });
-      return;
-    }
     const result = await ChallengesService.getChallenge(id);
     if (!result) {
       next({ statusCode: 404 });
@@ -286,7 +282,7 @@ const getChallenge: GetController<GetChallengeParam, never, GetChallengeResponse
  *         description: 서버 오류
  */
 
-const getChallengeList: GetController<never,GetChallengeListQuery,GetChallengeListResponse> = async (req, res, next) => {
+const getChallengeList: GetController<never,ChallengeRequestQueries,GetChallengeListResponse> = async (req, res, next) => {
   try {
     const {
       documentType,
@@ -296,43 +292,6 @@ const getChallengeList: GetController<never,GetChallengeListQuery,GetChallengeLi
       page = '1',
       limit = '10',
     } = req.query;
-    // 쿼리 구조분해 된 것들 각각 검증 필요
-    if (
-      documentType &&
-      !isValidEnumValue(DocumentType, documentType.toString())
-    ) {
-      next({ statusCode: 400 });
-      return;
-    }
-
-    if (
-      approvalStatus &&
-      !isValidEnumValue(ApprovalStatus, approvalStatus.toString())
-    ) {
-      next({ statusCode: 400 });
-      return;
-    }
-
-    // fields 검증 (배열 형식이나 단일 값 검증)
-    if (fields && !Array.isArray(fields)) {
-      if (!isValidEnumValue(FieldType, fields.toString())) {
-        return next({ statusCode: 400 });
-      }
-    } else if (Array.isArray(fields)) {
-      for (const field of fields) {
-        if (!isValidEnumValue(FieldType, field.toString())) {
-          return next({ statusCode: 400 });
-        }
-      }
-    }
-
-    const pageNumber = Number(page);
-    const limitNumber = Number(limit);
-
-    if (isNaN(pageNumber) || isNaN(limitNumber)) {
-      next({ statusCode: 400 });
-      return;
-    }
 
     const result = await ChallengesService.getChallengeList({
       documentType,
@@ -348,14 +307,141 @@ const getChallengeList: GetController<never,GetChallengeListQuery,GetChallengeLi
   }
 };
 
-// const postChallenge: Controller = async (req, res, next) => {
-  
-// };
+
+/**
+ * @swagger
+ * /api/challenges:
+ *   post:
+ *     tags:
+ *       - Challenges
+ *     summary: 챌린지 생성
+ *     description: 새로운 챌린지를 생성합니다.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 description: 챌린지 제목
+ *                 example: "프론트엔드 번역 챌린지"
+ *               description:
+ *                 type: string
+ *                 description: 챌린지 설명
+ *                 example: "프론트엔드 관련 문서를 번역하는 챌린지입니다."
+ *               documentType:
+ *                 type: string
+ *                 description: 문서 타입
+ *                 enum: [BLOG, OFFICIAL]
+ *                 example: "BLOG"
+ *               field:
+ *                 type: string
+ *                 description: 챌린지 분야
+ *                 enum: [NEXTJS, MODERNJS, API, WEB, CAREER]
+ *                 example: "NEXTJS"
+ *               maxParticipants:
+ *                 type: integer
+ *                 description: 최대 참가자 수
+ *                 example: 10
+ *               deadline:
+ *                 type: string
+ *                 format: date-time
+ *                 description: 챌린지 마감일
+ *                 example: "2025-04-01T00:00:00.000Z"
+ *               originURL:
+ *                 type: string
+ *                 format: url
+ *                 description: 원본 문서 URL
+ *                 example: "https://example.com/original-doc"
+ *     responses:
+ *       201:
+ *         description: 챌린지가 성공적으로 생성되었습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   description: 생성된 챌린지 ID
+ *                   example: "123e4567-e89b-12d3-a456-426614174000"
+ *                 title:
+ *                   type: string
+ *                   description: 챌린지 제목
+ *                   example: "프론트엔드 번역 챌린지"
+ *                 description:
+ *                   type: string
+ *                   description: 챌린지 설명
+ *                   example: "프론트엔드 관련 문서를 번역하는 챌린지입니다."
+ *                 documentType:
+ *                   type: string
+ *                   description: 문서 타입
+ *                   example: "BLOG"
+ *                 field:
+ *                   type: string
+ *                   description: 챌린지 분야
+ *                   example: "NEXTJS"
+ *                 maxParticipants:
+ *                   type: integer
+ *                   description: 최대 참가자 수
+ *                   example: 10
+ *                 deadline:
+ *                   type: string
+ *                   format: date-time
+ *                   description: 챌린지 마감일
+ *                   example: "2025-04-01T00:00:00.000Z"
+ *                 originURL:
+ *                   type: string
+ *                   format: url
+ *                   description: 원본 문서 URL
+ *                   example: "https://example.com/original-doc"
+ *                 createdAt:
+ *                   type: string
+ *                   format: date-time
+ *                   description: 생성된 날짜
+ *                   example: "2025-03-29T12:00:00.000Z"
+ *                 updatedAt:
+ *                   type: string
+ *                   format: date-time
+ *                   description: 마지막 업데이트 날짜
+ *                   example: "2025-03-29T12:00:00.000Z"
+ *       400:
+ *         description: 잘못된 요청 데이터
+ *       500:
+ *         description: 서버 오류
+ */
+const postChallenge: PostController<never,ChallengeRequestBody,PostChallengeResponse> = async (req, res, next) => {
+  try {
+    const {
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+    } = req.body;
+    const result = await ChallengesService.postChallenge({
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+    })
+    res.status(200).send({challenge: result});
+  } catch (err) {
+    next(err)
+  }
+};
 
 const ChallengesController = {
   getChallengeList,
   getChallenge,
-  // postChallenge,
+  postChallenge,
 };
 
 export default ChallengesController;

--- a/src/domains/challenges/challenges.routes.ts
+++ b/src/domains/challenges/challenges.routes.ts
@@ -2,13 +2,23 @@ import { Router } from 'express';
 import TranslationRouter from '../translations/translations.routes';
 import ParticipationRouter from '../participants/participants.routes';
 import ChallengesController from './challenges.controller';
+import { validateRequestData } from '../../middleware/validateRequestData';
+import { ChallengeBodySchema, ChallengeParamsSchema, ChallengeQueriesSchema } from './challenges.validation';
 const router = Router();
 
-router.get('/', ChallengesController.getChallengeList); //챌린지 목록 조회
-// router.post('/', ChallengesController.postChallenge); //챌린지 신청
+router.get(
+  '/',
+  validateRequestData({ params: ChallengeQueriesSchema }),
+  ChallengesController.getChallengeList
+); //챌린지 목록 조회
+router.post('/',validateRequestData({ body: ChallengeBodySchema}), ChallengesController.postChallenge); //챌린지 신청
 router.patch('/:challengeId'); //챌린지 수정
 router.delete('/:challengeId'); //챌린지 삭제
-router.get('/:challengeId', ChallengesController.getChallenge); //챌린지 상세 조회
+router.get(
+  '/:challengeId',
+  validateRequestData({ params: ChallengeParamsSchema }),
+  ChallengesController.getChallenge
+); //챌린지 상세 조회
 router.patch('/:challengeId/approve'); //챌린지 승인
 router.patch('/:challengeId/reject'); //챌린지 거절
 router.use('/:challengeId/translations', TranslationRouter);

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -1,15 +1,21 @@
-import { FieldType } from '@prisma/client';
+import { DocumentType, FieldType } from '@prisma/client';
 import prisma from '../../prismaClient';
-import { GetChallengeListQuery, GetChallengeResponse } from './challenges.type';
+import { GetChallengeResponse } from './challenges.type';
+import {
+  ChallengeParamsSchema,
+  ChallengeQueriesSchema,
+  ChallengeRequestBody,
+  ChallengeRequestQueries,
+} from './challenges.validation';
 
-const getChallenge = async (id : string): Promise<GetChallengeResponse> => {
+const getChallenge = async (id: string): Promise<GetChallengeResponse> => {
   const challenge = await prisma.challenge.findUnique({
     where: {
       id,
-    }
-  })
-  return {challenge};
-}
+    },
+  });
+  return { challenge };
+};
 
 const getChallengeList = async ({
   documentType,
@@ -18,7 +24,7 @@ const getChallengeList = async ({
   keyword,
   page,
   limit,
-}: GetChallengeListQuery) => {
+}: ChallengeRequestQueries) => {
   const pageNum = Number(page);
   const limitNum = Number(limit);
 
@@ -64,11 +70,36 @@ const getChallengeList = async ({
   return { challenges, totalCount };
 };
 
+const postChallenge = async ({
+  title,
+  description,
+  documentType,
+  field,
+  maxParticipants,
+  deadline,
+  originURL
+}: ChallengeRequestBody
+) => {
+  const challenge = await prisma.challenge.create({
+    data: {
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+      userId:"testUserId",
+    },
+  });
+
+  return challenge;
+};
 
 const ChallengesService = {
   getChallengeList,
   getChallenge,
-  // postChallenge,
+  postChallenge,
 };
 
 export default ChallengesService;

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -89,7 +89,7 @@ const postChallenge = async ({
       maxParticipants,
       deadline,
       originURL,
-      userId:"testUserId",
+      userId:"user-1",
     },
   });
 

--- a/src/domains/challenges/challenges.type.ts
+++ b/src/domains/challenges/challenges.type.ts
@@ -4,13 +4,8 @@ export interface GetChallengeParam {
   challengeId: string;
 }
 
-export interface GetChallengeListQuery {
-  documentType: DocumentType | undefined;
-  fields: FieldType | FieldType[];
-  approvalStatus: ApprovalStatus;
-  keyword: string | undefined;
-  page: string;
-  limit: string;
+export interface PostChallengeResponse {
+  challenge: Challenge | null;
 }
 
 export interface GetChallengeResponse {
@@ -20,4 +15,3 @@ export interface GetChallengeListResponse {
   challenges: Challenge[] | [];
   totalCount: number;
 }
-

--- a/src/domains/challenges/challenges.validation.ts
+++ b/src/domains/challenges/challenges.validation.ts
@@ -1,0 +1,31 @@
+import { ApprovalStatus, DocumentType, FieldType } from '@prisma/client';
+import z from 'zod';
+
+
+// TODO: 테스트용입니다. 나중에 삭제 예정입니다.
+export const ChallengeParamsSchema = z.object({
+  challengeId: z.string().uuid({ message: 'id는 uuid 형식이여야 합니다.' }),
+});
+
+export const ChallengeQueriesSchema = z.object({
+  documentType: z.nativeEnum(DocumentType).optional(),
+  fields: z.nativeEnum(FieldType).optional(),
+  approvalStatus: z.nativeEnum(ApprovalStatus).optional(),
+  keyword: z.string().optional(),
+  page: z.string().optional(),
+  limit: z.string().optional(),
+});
+
+export const ChallengeBodySchema = z.object({
+  title: z.string().min(2).max(15),
+  description: z.string().min(10).max(100),
+  documentType: z.nativeEnum(DocumentType),
+  field: z.nativeEnum(FieldType),
+  maxParticipants: z.number().min(5).max(20),
+  deadline: z.string().datetime(),
+  originURL: z.string().url(),
+});
+
+export type ChallengeRequestParams = z.infer<typeof ChallengeParamsSchema>;
+export type ChallengeRequestQueries = z.infer<typeof ChallengeQueriesSchema>;
+export type ChallengeRequestBody = z.infer<typeof ChallengeBodySchema>;

--- a/src/middleware/validateRequestData.ts
+++ b/src/middleware/validateRequestData.ts
@@ -14,7 +14,7 @@ export const validateRequestData =
       if (schemas.body) {
         const result = schemas.body.safeParse(req.body);
         if (!result.success) {
-          next({ statusCode: 400, message: result.error.flatten() });
+          next({ statusCode: 400 });
           return;
         }
         req.body = result.data;
@@ -24,7 +24,7 @@ export const validateRequestData =
       if (schemas.query) {
         const result = schemas.query.safeParse(req.query);
         if (!result.success) {
-          next({ statusCode: 400, message: result.error.flatten() });
+          next({ statusCode: 400 });
           return;
         }
         req.query = result.data;
@@ -34,7 +34,7 @@ export const validateRequestData =
       if (schemas.params) {
         const result = schemas.params.safeParse(req.params);
         if (!result.success) {
-          next({ statusCode: 400, message: result.error.flatten() });
+          next({ statusCode: 400 });
           return;
         }
         req.params = result.data;

--- a/src/types/express.ts
+++ b/src/types/express.ts
@@ -14,8 +14,8 @@ export type PostController<P, B, D> = (
   next: NextFunction
 ) => Promise<void>;
 
-// PUT 요청용 컨트롤러
-export type PutController<P, B, D> = (
+// PATCH 요청용 컨트롤러
+export type PatchController<P, B, D> = (
   req: Request<P, any, B>, // Query는 없음
   res: Response<D>,
   next: NextFunction


### PR DESCRIPTION
## 📌 개요

- 챌린지 생성 API 구현

## ✨ 주요 변경 사항

- zod 사용한 검증 미들웨어를 거칩니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 백엔드 컨벤션의 검증 미들웨어 사용 부분 확인 부탁 드립니다.
- userId 부분은 나중에 승우님께서 로그인 인증 미들웨어 구현 후 다시 작업하려고 임시로 시드 데이터의 userId를 사용하여 테스트 진행했습니다.

## 🔗 관련 이슈

#29 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
-
![image](https://github.com/user-attachments/assets/cf6451ce-5f84-4399-a5e5-21c38c79f0cf)

글자 수 제한을 걸어뒀습니다.

  title: z.string().min(2).max(15), - 2글자 이상 15글자 이하
  description: z.string().min(10).max(100), - 10글자 이상 100글자 이하

참여자 수 제한을 걸어뒀습니다.

  maxParticipants: z.number().min(5).max(20), - 5명부터 20명까지