### PR TITLE
[Feat] jwt 토큰 인증 미들웨어 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.3.1",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
+        "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.14",
         "@types/date-fns": "^2.5.3",
         "@types/express": "^4.17.21",
@@ -300,6 +302,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
+      "integrity": "sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -837,6 +849,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "dotenv": "^16.3.1",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
+    "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.14",
     "@types/date-fns": "^2.5.3",
     "@types/express": "^4.17.21",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 import router from './domains/routes';
 import { setupSwagger } from './swagger.ts';
 import errorHandler from './middleware/errorHandler.ts';
-
+import cookieParser from 'cookie-parser';
 
 dotenv.config();
 
@@ -12,6 +12,7 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use(cookieParser());
 
 app.use('/test', (req, res, next) => next({statusCode: 401, message: "test"}));
 app.use('/api', router);

--- a/src/domains/auth/auth.routes.ts
+++ b/src/domains/auth/auth.routes.ts
@@ -9,6 +9,7 @@ import {
   testQueriesSchema,
 } from './auth.types';
 import { validateRequestData } from '../../middleware/validateRequestData';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 
 const router = Router();
 
@@ -28,13 +29,10 @@ router.post('/logout'); //로그아웃
 
 // TODO: 테스트 용 api, 삭제 예정
 router.post(
-  '/test/:id/:params2',
-  validateRequestData({
-    params: testParamsSchema,
-    query: testQueriesSchema,
-    body: testBodySchema,
-  }),
+  '/test',
+  verifyJWTToken,
   async (req: Request, res: Response, next: NextFunction) => {
+    console.log('Hello!!!!!!!!!!!!!!!!!!!!!!!');
     console.log(req.params);
     console.log(req.query);
     const { email, password } = req.body;

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -50,11 +50,34 @@ const saveRefreshToken = async (email: string, refreshToken: string) => {
   });
 };
 
+const getRefreshToken = async (id: string) => {
+  const user = await prisma.user.findUnique({
+    where: {
+      id,
+    },
+    select: {
+      refreshToken: true,
+    },
+  });
+  return user?.refreshToken;
+};
+
+const updateRefreshToken = async (id: string, newRefreshToken: string) => {
+  return await prisma.user.update({
+    where: {
+      id,
+    },
+    data: { refreshToken: newRefreshToken },
+  });
+};
+
 const AuthService = {
   createUser,
   checkEmail,
   checkPassword,
   saveRefreshToken,
+  getRefreshToken,
+  updateRefreshToken,
 };
 
 export default AuthService;

--- a/src/domains/challenges/challenges.routes.ts
+++ b/src/domains/challenges/challenges.routes.ts
@@ -4,7 +4,10 @@ import ParticipationRouter from '../participants/participants.routes';
 import ChallengesController from './challenges.controller';
 import { validateRequestData } from '../../middleware/validateRequestData';
 import { ChallengeBodySchema, ChallengeParamsSchema, ChallengeQueriesSchema } from './challenges.validation';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 const router = Router();
+
+router.use(verifyJWTToken);
 
 router.get(
   '/',

--- a/src/middleware/verifyJWTToken.ts
+++ b/src/middleware/verifyJWTToken.ts
@@ -1,0 +1,64 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from '../utils/jwt';
+import AuthService from '../domains/auth/auth.service';
+
+export const verifyJWTToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const authorization = req.headers.authorization;
+    if (!authorization?.startsWith('Bearer ')) {
+      return next({ statusCode: 401, message: 'Bearer 없음.' });
+    }
+
+    const accessToken = authorization.split(' ')[1];
+    const payloadAccess = jwt.verifyToken(accessToken);
+
+    if (payloadAccess) {
+      req.user = payloadAccess;
+      return next();
+    }
+
+    const refreshToken = req.cookies.refreshToken;
+    if (!refreshToken) {
+      return next({ statusCode: 401, message: 'refreshToken 없음' });
+    }
+
+    const payloadRefresh = jwt.verifyToken(refreshToken);
+    if (!payloadRefresh) {
+      return next({ statusCode: 401, message: 'refreshToken 만료' });
+    }
+
+    const savedRefreshToken = await AuthService.getRefreshToken(
+      payloadRefresh.id
+    );
+    // 굳이 있어야 되나 싶음..
+    if (savedRefreshToken !== refreshToken) {
+      return next({ statusCode: 401, message: '저장된 refreshToken 불일치' });
+    }
+
+    const newUserInfo = {
+      id: payloadRefresh.id,
+      role: payloadRefresh.role,
+    };
+
+    const newAccessToken = jwt.createToken(newUserInfo, 'access');
+    const newRefreshToken = jwt.createToken(newUserInfo, 'refresh');
+
+    await AuthService.updateRefreshToken(payloadRefresh.id, newRefreshToken);
+
+    res.set('Authorization', `Bearer ${newAccessToken}`);
+    res.cookie('refreshToken', newRefreshToken, {
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true,
+    });
+
+    req.user = newUserInfo;
+    next();
+  } catch (error) {
+    next({ statusCode: 500, message: '인증 처리 중 오류 발생' });
+  }
+};

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -10,6 +10,20 @@ const options: swaggerJSDoc.Options = {
       version: '1.0.0',
       description: 'Express + TypeScript + Prisma API 문서',
     },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+    security: [
+      {
+        bearerAuth: [],
+      },
+    ],
   },
   apis: ['./src/domains/*/*.ts'], // API 경로
 };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: string;
+        role: string;
+      };
+    }
+  }
+}
+
+export {};

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -16,8 +16,8 @@ const createToken = (
     id: user.id,
     role: user.role,
   };
-  const expiresIn = tokenType === 'access' ? '10s' : '1m';
-return jwt.sign(payload, secretKey, { expiresIn });
+  const expiresIn = tokenType === 'access' ? '10m' : '1h';
+  return jwt.sign(payload, secretKey, { expiresIn });
 };
 
 const verifyToken = (token: string): CustomJwtPayload | null => {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,18 +1,35 @@
 import { User } from '@prisma/client';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 
-const screctKey = process.env.JWT_SECRET_KEY || 'secret';
+interface CustomJwtPayload extends JwtPayload {
+  id: string;
+  role: 'USER' | 'ADMIN';
+}
 
-const createToken = (user: User, tokenType: 'access' | 'refresh') => {
+const secretKey = process.env.JWT_SECRET_KEY || 'secret';
+
+const createToken = (
+  user: { id: string; role: 'USER' | 'ADMIN' },
+  tokenType: 'access' | 'refresh'
+) => {
   const payload = {
     id: user.id,
     role: user.role,
   };
-  const expiresIn = tokenType == 'access' ? '1h' : '1w';
-  const token = jwt.sign(payload, screctKey, { expiresIn });
-  return token;
+  const expiresIn = tokenType === 'access' ? '10s' : '1m';
+return jwt.sign(payload, secretKey, { expiresIn });
+};
+
+const verifyToken = (token: string): CustomJwtPayload | null => {
+  try {
+    const payload = jwt.verify(token, secretKey) as CustomJwtPayload;
+    return payload;
+  } catch (error) {
+    return null;
+  }
 };
 
 export default {
   createToken,
+  verifyToken,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["src", "prisma"], // 현재 폴더 전체를 포함
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
## 📌 개요
- jwt 인증 미들웨어 구현

## ✨ 주요 변경 사항
- accessToken, refreshToken 인증하는 미들웨어 추가
- Swagger 문서에서 적용 가능

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)
### 인증 방식
- accessToken은 http header Authorization에 `Bearer {accessToken}` 넣어야 함.
- refreshToken은 cookie로 전달됨.
- 지금 현재, accessToken 10분 refreshToken 1시간으로 설정됨.
- 슬라이딩 세션 구현함. refreshToken 토큰이 api 호출시 계속 연장 됨. - 단 refreshToken 토큰 만료 시간이 넘어가면(1시간) 재 로그인 해야 함.

### 스웨거  accessToken 사용 방법
- 로그인 API를 호출해서 accessToken 발급
- Swagger도 웹페이지 임으로 자동으로 refreshToken은 브라우저 쿠키에 저장됨.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4984a254-505f-4f7c-870c-2e58ec29dbcb" />
<br><br>

최상단에 `Authorize`에 accessToken 입력
<img width="822" alt="image" src="https://github.com/user-attachments/assets/a2759db2-3ee3-4ff4-9ed7-6c58002c7780" />


## 🔗 관련 이슈
#30 

## 📸 스크린샷
