### PR TITLE
[Feature] 피드백 목록 조회, 생성, 수정, 삭제 API 구현

### DIFF
--- a/prisma/schema/Feedback.prisma
+++ b/prisma/schema/Feedback.prisma
@@ -10,7 +10,6 @@ model Feedback {
   content        String
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt
-  deletedAt      DateTime?
 
   @@map("feedbacks")
 }

--- a/prisma/seeds/feedback.seed.ts
+++ b/prisma/seeds/feedback.seed.ts
@@ -7,12 +7,15 @@ export const seedFeedbacks = async (prisma: PrismaClient) => {
 
   type CreateFeedbackInput = {
     id: string;
+    idx: number;
     translationId: string;
     userId: string;
     userNickname: string;
     userProfileImg?: string | null;
     content: string;
   };
+
+  let idx = 0;
 
   const feedbacks: CreateFeedbackInput[] = [];
 
@@ -27,6 +30,7 @@ export const seedFeedbacks = async (prisma: PrismaClient) => {
     for (const user of feedbackUsers) {
       feedbacks.push({
         id: uuidv4(),
+        idx: idx++,
         translationId: translation.id,
         userId: user.id,
         userNickname: user.nickname,

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -31,6 +31,16 @@ const checkEmail = async (email: string) => {
   return user;
 };
 
+const checkId = async (id: string) => {
+  const user = await prisma.user.findUnique({
+    where: {
+      id,
+    },
+  });
+
+  return user;
+};
+
 const checkPassword = async (
   userInputPassword: string,
   hashedPassword: string
@@ -74,6 +84,7 @@ const updateRefreshToken = async (id: string, newRefreshToken: string) => {
 const AuthService = {
   createUser,
   checkEmail,
+  checkId,
   checkPassword,
   saveRefreshToken,
   getRefreshToken,

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -1,0 +1,33 @@
+import { GetController } from '../../types/express';
+import { GetFeedBackListParams } from './feedbacks.validation';
+import FeedbackService from './feedbacks.service';
+import { GetFeedbackListResponse } from './feedbacks.type';
+
+const getFeedBackList: GetController<
+  GetFeedBackListParams,
+  never,
+  GetFeedbackListResponse
+> = async (req, res, next) => {
+  const translationId = req.params.translationId;
+
+  const existedTranslaition = await FeedbackService.checkTranslations(
+    translationId
+  );
+
+  if (!existedTranslaition) {
+    return next({ statusCode: 400, message: '존재하지 않는 translationId' });
+  }
+
+  const feedbacks = await FeedbackService.fetchFeedbackList(
+    existedTranslaition.id
+  );
+
+  res.status(200).json({
+    feedbacks: feedbacks,
+  });
+  return;
+};
+
+export default {
+  getFeedBackList,
+};

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -1,7 +1,11 @@
-import { GetController } from '../../types/express';
-import { GetFeedBackListParams } from './feedbacks.validation';
+import { GetController, PostController } from '../../types/express';
+import { FeedBackParams, PostFeedBackBodyParams } from './feedbacks.validation';
 import FeedbackService from './feedbacks.service';
-import { GetFeedbackListResponse } from './feedbacks.type';
+import {
+  GetFeedbackListResponse,
+  PostFeedBackResponse,
+} from './feedbacks.type';
+import AuthService from '../auth/auth.service';
 
 /**
  * @swagger
@@ -99,7 +103,7 @@ import { GetFeedbackListResponse } from './feedbacks.type';
  *         description: 서버 오류
  */
 const getFeedBackList: GetController<
-  GetFeedBackListParams,
+  FeedBackParams,
   never,
   GetFeedbackListResponse
 > = async (req, res, next) => {
@@ -123,6 +127,42 @@ const getFeedBackList: GetController<
   return;
 };
 
+const postFeedback: PostController<
+  FeedBackParams,
+  PostFeedBackBodyParams,
+  PostFeedBackResponse
+> = async (req, res, next) => {
+  const translationId = req.params.translationId;
+  const { userId, content } = req.body;
+
+  const existedTranslaition = await FeedbackService.checkTranslations(
+    translationId
+  );
+
+  if (!existedTranslaition) {
+    return next({ statusCode: 400, message: '존재하지 않는 translationId' });
+  }
+
+  const existedUser = await AuthService.checkId(userId);
+
+  if (!existedUser) {
+    return next({ statusCode: 400, message: '존재하지 않는 유저' });
+  }
+
+  const feedback = await FeedbackService.createFeedback({
+    translationId,
+    userId: existedUser.id,
+    userNickName: existedUser.nickname,
+    content,
+  });
+
+  res.status(201).json({
+    feedback,
+  });
+  return;
+};
+
 export default {
   getFeedBackList,
+  postFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -411,7 +411,7 @@ const patchFeedback: PatchController<
  *         schema:
  *           type: string
  *     responses:
- *       204:
+ *       200:
  *         description: 피드백이 성공적으로 삭제됨
  *         content:
  *           application/json:
@@ -495,7 +495,7 @@ const deleteFeedback: DeleteController<
 
   const deletedFeedback = await FeedbackService.deleteFeedback(feedbackId);
 
-  res.status(204).json({
+  res.status(200).json({
     feedback: deletedFeedback,
   });
   return;

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -1,8 +1,17 @@
-import { GetController, PostController } from '../../types/express';
-import { FeedBackParams, PostFeedBackBodyParams } from './feedbacks.validation';
+import {
+  GetController,
+  PatchController,
+  PostController,
+} from '../../types/express';
+import {
+  FeedBackParams,
+  ModifyFeedBackParams,
+  PostFeedBackBodyParams,
+} from './feedbacks.validation';
 import FeedbackService from './feedbacks.service';
 import {
   GetFeedbackListResponse,
+  PatchFeedBackResponse,
   PostFeedBackResponse,
 } from './feedbacks.type';
 import AuthService from '../auth/auth.service';
@@ -149,9 +158,6 @@ const getFeedBackList: GetController<
  *           schema:
  *             type: object
  *             properties:
- *               userId:
- *                 type: string
- *                 description: 피드백을 작성할 사용자 ID
  *               content:
  *                 type: string
  *                 description: 피드백 내용
@@ -224,7 +230,8 @@ const postFeedback: PostController<
   PostFeedBackResponse
 > = async (req, res, next) => {
   const translationId = req.params.translationId;
-  const { userId, content } = req.body;
+  const { content } = req.body;
+  const userId = req.user?.id ?? '';
 
   const existedTranslaition = await FeedbackService.checkTranslations(
     translationId
@@ -253,7 +260,40 @@ const postFeedback: PostController<
   return;
 };
 
+const patchFeedback: PatchController<
+  ModifyFeedBackParams,
+  PostFeedBackBodyParams,
+  PatchFeedBackResponse
+> = async (req, res, next) => {
+  const feedbackId = req.params.feedbackId;
+  const { content } = req.body;
+  const userId = req.user?.id ?? '';
+  const userRole = req.user?.role ?? 'USER';
+
+  const existedFeedback = await FeedbackService.checkFeedbackByID(feedbackId);
+
+  if (!existedFeedback) {
+    return next({ statusCode: 400, message: '존재하지 않는 feedbackId' });
+  }
+
+  if (existedFeedback.userId !== userId && userRole !== 'ADMIN') {
+    return next({ statusCode: 403, message: '권한이 없습니다.' });
+  }
+
+  const updatedFeedback = await FeedbackService.updateFeedback(
+    feedbackId,
+    content
+  );
+
+  res.status(200).json({
+    feedback: updatedFeedback,
+  });
+  
+  return;
+};
+
 export default {
   getFeedBackList,
   postFeedback,
+  patchFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -389,6 +389,91 @@ const patchFeedback: PatchController<
   return;
 };
 
+/**
+ * @swagger
+ * /api/translations/{translationId}/feedbacks/{feedbackId}:
+ *   delete:
+ *     tags:
+ *       - Feedbacks
+ *     summary: 번역에 대한 피드백 삭제
+ *     description: 특정 번역에 대한 피드백을 삭제합니다. 피드백 작성자 또는 관리자만 삭제 가능합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 피드백이 달린 번역의 ID
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: feedbackId
+ *         required: true
+ *         description: 삭제할 피드백의 ID
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: 피드백이 성공적으로 삭제됨
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feedback:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 피드백 ID
+ *                     idx:
+ *                       type: integer
+ *                       description: 피드백 인덱스
+ *                     translationId:
+ *                       type: string
+ *                       description: 피드백이 달린 번역 ID
+ *                     userId:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 ID
+ *                     userNickname:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 닉네임
+ *                     userProfileImg:
+ *                       type: string
+ *                       nullable: true
+ *                       description: 피드백을 작성한 사용자 프로필 이미지
+ *                     content:
+ *                       type: string
+ *                       description: 피드백 내용
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 작성 시간
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 수정 시간
+ *                     deletedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 삭제 시간
+ *             example:
+ *               feedback:
+ *                 id: "4b40576d-7eaf-4d3c-a577-918ebd55905c"
+ *                 idx: 3
+ *                 translationId: "02f43933-41fb-4dd5-8426-700f17beb6fa"
+ *                 userId: "a7a54ed2-53be-4931-b8f4-f87bd4358adf"
+ *                 userNickname: "codeit"
+ *                 userProfileImg: null
+ *                 content: "삭제된 피드백입니다."
+ *                 createdAt: "2025-04-01T08:09:43.305Z"
+ *                 updatedAt: "2025-04-01T08:30:00.000Z"
+ *                 deletedAt: "2025-04-01T09:00:00.000Z"
+ *       400:
+ *         description: 존재하지 않는 feedbackId
+ *       403:
+ *         description: 권한이 없음 (피드백 작성자 또는 관리자가 아님)
+ *       500:
+ *         description: 서버 오류
+ */
 const deleteFeedback: DeleteController<
   ModifyFeedBackParams,
   never,

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -260,6 +260,102 @@ const postFeedback: PostController<
   return;
 };
 
+/**
+ * @swagger
+ * /api/translations/{translationId}/feedbacks/{feedbackId}:
+ *   patch:
+ *     tags:
+ *       - Feedbacks
+ *     summary: 번역에 대한 피드백 수정
+ *     description: 특정 번역에 대한 피드백을 수정합니다. 피드백 작성자 또는 관리자만 수정 가능합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 피드백이 달린 번역의 ID
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: feedbackId
+ *         required: true
+ *         description: 수정할 피드백의 ID
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               content:
+ *                 type: string
+ *                 description: 수정할 피드백 내용
+ *     responses:
+ *       200:
+ *         description: 피드백이 성공적으로 수정됨
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feedback:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 피드백 ID
+ *                     idx:
+ *                       type: integer
+ *                       description: 피드백 인덱스
+ *                     translationId:
+ *                       type: string
+ *                       description: 피드백이 달린 번역 ID
+ *                     userId:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 ID
+ *                     userNickname:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 닉네임
+ *                     userProfileImg:
+ *                       type: string
+ *                       nullable: true
+ *                       description: 피드백을 작성한 사용자 프로필 이미지
+ *                     content:
+ *                       type: string
+ *                       description: 수정된 피드백 내용
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 작성 시간
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 수정 시간
+ *                     deletedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       description: 피드백 삭제 시간
+ *             example:
+ *               feedback:
+ *                 id: "4b40576d-7eaf-4d3c-a577-918ebd55905c"
+ *                 idx: 3
+ *                 translationId: "02f43933-41fb-4dd5-8426-700f17beb6fa"
+ *                 userId: "a7a54ed2-53be-4931-b8f4-f87bd4358adf"
+ *                 userNickname: "codeit"
+ *                 userProfileImg: null
+ *                 content: "수정된 피드백 내용입니다."
+ *                 createdAt: "2025-04-01T08:09:43.305Z"
+ *                 updatedAt: "2025-04-01T08:30:00.000Z"
+ *                 deletedAt: null
+ *       400:
+ *         description: 존재하지 않는 feedbackId
+ *       403:
+ *         description: 권한이 없음 (피드백 작성자 또는 관리자가 아님)
+ *       500:
+ *         description: 서버 오류
+ */
 const patchFeedback: PatchController<
   ModifyFeedBackParams,
   PostFeedBackBodyParams,

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteController,
   GetController,
   PatchController,
   PostController,
@@ -10,6 +11,7 @@ import {
 } from './feedbacks.validation';
 import FeedbackService from './feedbacks.service';
 import {
+  DeleteFeedBackResponse,
   GetFeedbackListResponse,
   PatchFeedBackResponse,
   PostFeedBackResponse,
@@ -384,7 +386,33 @@ const patchFeedback: PatchController<
   res.status(200).json({
     feedback: updatedFeedback,
   });
-  
+  return;
+};
+
+const deleteFeedback: DeleteController<
+  ModifyFeedBackParams,
+  never,
+  DeleteFeedBackResponse
+> = async (req, res, next) => {
+  const feedbackId = req.params.feedbackId;
+  const userId = req.user?.id ?? '';
+  const userRole = req.user?.role ?? 'USER';
+
+  const existedFeedback = await FeedbackService.checkFeedbackByID(feedbackId);
+
+  if (!existedFeedback) {
+    return next({ statusCode: 400, message: '존재하지 않는 feedbackId' });
+  }
+
+  if (existedFeedback.userId !== userId && userRole !== 'ADMIN') {
+    return next({ statusCode: 403, message: '권한이 없습니다.' });
+  }
+
+  const deletedFeedback = await FeedbackService.deleteFeedback(feedbackId);
+
+  res.status(204).json({
+    feedback: deletedFeedback,
+  });
   return;
 };
 
@@ -392,4 +420,5 @@ export default {
   getFeedBackList,
   postFeedback,
   patchFeedback,
+  deleteFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -3,6 +3,101 @@ import { GetFeedBackListParams } from './feedbacks.validation';
 import FeedbackService from './feedbacks.service';
 import { GetFeedbackListResponse } from './feedbacks.type';
 
+/**
+ * @swagger
+ * /api/translations/{translationId}/feedbacks:
+ *   get:
+ *     tags:
+ *       - Feedbacks
+ *     summary: 번역에 대한 피드백 목록 조회
+ *     description: 특정 번역에 대한 피드백 목록을 조회합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 조회할 번역의 ID
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 성공적으로 피드백 목록을 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feedbacks:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         description: 피드백 ID
+ *                       idx:
+ *                         type: integer
+ *                         description: 피드백 인덱스
+ *                       translationId:
+ *                         type: string
+ *                         description: 피드백이 달린 번역 ID
+ *                       userId:
+ *                         type: string
+ *                         description: 피드백을 작성한 사용자 ID
+ *                       userNickname:
+ *                         type: string
+ *                         description: 피드백을 작성한 사용자 닉네임
+ *                       userProfileImg:
+ *                         type: string
+ *                         nullable: true
+ *                         description: 피드백을 작성한 사용자 프로필 이미지
+ *                       content:
+ *                         type: string
+ *                         description: 피드백 내용
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                         description: 피드백 작성 시간
+ *                       updatedAt:
+ *                         type: string
+ *                         format: date-time
+ *                         description: 피드백 수정 시간
+ *                       deletedAt:
+ *                         type: string
+ *                         format: date-time
+ *                         nullable: true
+ *                         description: 피드백 삭제 시간
+ *             example:
+ *               feedbacks: [
+ *                 {
+ *                   "id": "74f4e104-d49e-4cbb-93c0-8b67b7333975",
+ *                   "idx": 70,
+ *                   "translationId": "02f43933-41fb-4dd5-8426-700f17beb6fa",
+ *                   "userId": "user-1",
+ *                   "userNickname": "총명한판다",
+ *                   "userProfileImg": null,
+ *                   "content": "다음에도 이런 번역 기대할게요 👍",
+ *                   "createdAt": "2025-04-01T02:40:45.656Z",
+ *                   "updatedAt": "2025-04-01T02:40:45.656Z",
+ *                   "deletedAt": null
+ *                 },
+ *                 {
+ *                   "id": "2defb6bd-cd68-4657-bc63-38e071c8770f",
+ *                   "idx": 71,
+ *                   "translationId": "02f43933-41fb-4dd5-8426-700f17beb6fa",
+ *                   "userId": "user-9",
+ *                   "userNickname": "태일윈드너구리",
+ *                   "userProfileImg": null,
+ *                   "content": "구체적인 예시 덕분에 이해가 쉬웠어요!",
+ *                   "createdAt": "2025-04-01T02:40:45.656Z",
+ *                   "updatedAt": "2025-04-01T02:40:45.656Z",
+ *                   "deletedAt": null
+ *                 }
+ *               ]
+ *       400:
+ *         description: 존재하지 않는 translationId
+ *       500:
+ *         description: 서버 오류
+ */
 const getFeedBackList: GetController<
   GetFeedBackListParams,
   never,

--- a/src/domains/feedbacks/feedbacks.controller.ts
+++ b/src/domains/feedbacks/feedbacks.controller.ts
@@ -127,6 +127,97 @@ const getFeedBackList: GetController<
   return;
 };
 
+/**
+ * @swagger
+ * /api/translations/{translationId}/feedbacks:
+ *   post:
+ *     tags:
+ *       - Feedbacks
+ *     summary: 번역에 대한 피드백 생성
+ *     description: 특정 번역에 대한 피드백을 생성합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 피드백을 생성할 번역의 ID
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 description: 피드백을 작성할 사용자 ID
+ *               content:
+ *                 type: string
+ *                 description: 피드백 내용
+ *     responses:
+ *       201:
+ *         description: 피드백이 성공적으로 생성됨
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feedback:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 생성된 피드백 ID
+ *                     idx:
+ *                       type: integer
+ *                       description: 피드백 인덱스
+ *                     translationId:
+ *                       type: string
+ *                       description: 피드백이 달린 번역 ID
+ *                     userId:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 ID
+ *                     userNickname:
+ *                       type: string
+ *                       description: 피드백을 작성한 사용자 닉네임
+ *                     userProfileImg:
+ *                       type: string
+ *                       nullable: true
+ *                       description: 피드백을 작성한 사용자 프로필 이미지
+ *                     content:
+ *                       type: string
+ *                       description: 피드백 내용
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 작성 시간
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 피드백 수정 시간
+ *                     deletedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       description: 피드백 삭제 시간
+ *             example:
+ *               feedback:
+ *                 id: "4b40576d-7eaf-4d3c-a577-918ebd55905c"
+ *                 idx: 3
+ *                 translationId: "02f43933-41fb-4dd5-8426-700f17beb6fa"
+ *                 userId: "a7a54ed2-53be-4931-b8f4-f87bd4358adf"
+ *                 userNickname: "codeit"
+ *                 userProfileImg: null
+ *                 content: "테스트 피드백 우리지금만나 아 당장만나 우리지금만나 아 당장만나"
+ *                 createdAt: "2025-04-01T08:09:43.305Z"
+ *                 updatedAt: "2025-04-01T08:09:43.305Z"
+ *                 deletedAt: null
+ *       400:
+ *         description: 존재하지 않는 translationId 또는 유저
+ *       500:
+ *         description: 서버 오류
+ */
 const postFeedback: PostController<
   FeedBackParams,
   PostFeedBackBodyParams,

--- a/src/domains/feedbacks/feedbacks.routes.ts
+++ b/src/domains/feedbacks/feedbacks.routes.ts
@@ -1,16 +1,20 @@
 import { Router } from 'express';
 import FeedbackController from './feedbacks.controller';
 import { validateRequestData } from '../../middleware/validateRequestData';
-import { GetFeedBackListSchema } from './feedbacks.validation';
+import { FeedBackSchema, PostFeedBackBodySchema } from './feedbacks.validation';
 
 const router = Router({ mergeParams: true });
 
 router.get(
   '/',
-  validateRequestData({ params: GetFeedBackListSchema }),
+  validateRequestData({ params: FeedBackSchema }),
   FeedbackController.getFeedBackList
 ); // 피드백 조회
-router.post('/'); // 피드백 생성
+router.post(
+  '/',
+  validateRequestData({ params: FeedBackSchema, body: PostFeedBackBodySchema }),
+  FeedbackController.postFeedback
+); // 피드백 생성
 router.patch('/:feedbackId'); // 피드백 수정
 router.delete('/:feedbackId'); // 피드백 삭제
 

--- a/src/domains/feedbacks/feedbacks.routes.ts
+++ b/src/domains/feedbacks/feedbacks.routes.ts
@@ -1,8 +1,15 @@
 import { Router } from 'express';
+import FeedbackController from './feedbacks.controller';
+import { validateRequestData } from '../../middleware/validateRequestData';
+import { GetFeedBackListSchema } from './feedbacks.validation';
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
-router.get('/'); // 피드백 조회
+router.get(
+  '/',
+  validateRequestData({ params: GetFeedBackListSchema }),
+  FeedbackController.getFeedBackList
+); // 피드백 조회
 router.post('/'); // 피드백 생성
 router.patch('/:feedbackId'); // 피드백 수정
 router.delete('/:feedbackId'); // 피드백 삭제

--- a/src/domains/feedbacks/feedbacks.routes.ts
+++ b/src/domains/feedbacks/feedbacks.routes.ts
@@ -30,6 +30,10 @@ router.patch(
   }),
   FeedbackController.patchFeedback
 ); // 피드백 수정
-router.delete('/:feedbackId'); // 피드백 삭제
+router.delete(
+  '/:feedbackId',
+  validateRequestData({ params: ModifyFeedBackSchema }),
+  FeedbackController.deleteFeedback
+); // 피드백 삭제
 
 export default router;

--- a/src/domains/feedbacks/feedbacks.routes.ts
+++ b/src/domains/feedbacks/feedbacks.routes.ts
@@ -1,9 +1,16 @@
 import { Router } from 'express';
 import FeedbackController from './feedbacks.controller';
 import { validateRequestData } from '../../middleware/validateRequestData';
-import { FeedBackSchema, PostFeedBackBodySchema } from './feedbacks.validation';
+import {
+  FeedBackSchema,
+  ModifyFeedBackSchema,
+  PostFeedBackBodySchema,
+} from './feedbacks.validation';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 
 const router = Router({ mergeParams: true });
+
+router.use(verifyJWTToken);
 
 router.get(
   '/',
@@ -15,7 +22,14 @@ router.post(
   validateRequestData({ params: FeedBackSchema, body: PostFeedBackBodySchema }),
   FeedbackController.postFeedback
 ); // 피드백 생성
-router.patch('/:feedbackId'); // 피드백 수정
+router.patch(
+  '/:feedbackId',
+  validateRequestData({
+    params: ModifyFeedBackSchema,
+    body: PostFeedBackBodySchema,
+  }),
+  FeedbackController.patchFeedback
+); // 피드백 수정
 router.delete('/:feedbackId'); // 피드백 삭제
 
 export default router;

--- a/src/domains/feedbacks/feedbacks.service.ts
+++ b/src/domains/feedbacks/feedbacks.service.ts
@@ -1,5 +1,12 @@
 import prisma from '../../prismaClient';
 
+interface CreateFeedbackParams {
+  translationId: string;
+  userId: string;
+  userNickName: string;
+  content: string;
+}
+
 const checkTranslations = async (translationId: string) => {
   const translation = await prisma.translation.findUnique({
     where: {
@@ -18,7 +25,25 @@ const fetchFeedbackList = async (translationId: string) => {
   return feedbacks;
 };
 
+const createFeedback = async ({
+  translationId,
+  userId,
+  userNickName,
+  content,
+}: CreateFeedbackParams) => {
+  const feedback = await prisma.feedback.create({
+    data: {
+      translationId,
+      userId,
+      userNickname: userNickName,
+      content,
+    },
+  });
+  return feedback;
+};
+
 export default {
   fetchFeedbackList,
   checkTranslations,
+  createFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.service.ts
+++ b/src/domains/feedbacks/feedbacks.service.ts
@@ -42,8 +42,31 @@ const createFeedback = async ({
   return feedback;
 };
 
+const checkFeedbackByID = async (feedbackId: string) => {
+  const feedback = await prisma.feedback.findUnique({
+    where: {
+      id: feedbackId,
+    },
+  });
+  return feedback;
+};
+
+const updateFeedback = async (feedbackId: string, content: string) => {
+  const feedback = await prisma.feedback.update({
+    where: {
+      id: feedbackId,
+    },
+    data: {
+      content,
+    },
+  });
+  return feedback;
+};
+
 export default {
   fetchFeedbackList,
   checkTranslations,
   createFeedback,
+  checkFeedbackByID,
+  updateFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.service.ts
+++ b/src/domains/feedbacks/feedbacks.service.ts
@@ -1,0 +1,24 @@
+import prisma from '../../prismaClient';
+
+const checkTranslations = async (translationId: string) => {
+  const translation = await prisma.translation.findUnique({
+    where: {
+      id: translationId,
+    },
+  });
+  return translation;
+};
+
+const fetchFeedbackList = async (translationId: string) => {
+  const feedbacks = await prisma.feedback.findMany({
+    where: {
+      translationId,
+    },
+  });
+  return feedbacks;
+};
+
+export default {
+  fetchFeedbackList,
+  checkTranslations,
+};

--- a/src/domains/feedbacks/feedbacks.service.ts
+++ b/src/domains/feedbacks/feedbacks.service.ts
@@ -63,10 +63,20 @@ const updateFeedback = async (feedbackId: string, content: string) => {
   return feedback;
 };
 
+const deleteFeedback = async (feedbackId: string) => {
+  const feedback = await prisma.feedback.delete({
+    where: {
+      id: feedbackId,
+    },
+  });
+  return feedback;
+};
+
 export default {
   fetchFeedbackList,
   checkTranslations,
   createFeedback,
   checkFeedbackByID,
   updateFeedback,
+  deleteFeedback,
 };

--- a/src/domains/feedbacks/feedbacks.type.ts
+++ b/src/domains/feedbacks/feedbacks.type.ts
@@ -3,3 +3,7 @@ import { Feedback } from '@prisma/client';
 export interface GetFeedbackListResponse {
   feedbacks: Feedback[];
 }
+
+export interface PostFeedBackResponse {
+  feedback: Feedback;
+}

--- a/src/domains/feedbacks/feedbacks.type.ts
+++ b/src/domains/feedbacks/feedbacks.type.ts
@@ -1,0 +1,5 @@
+import { Feedback } from '@prisma/client';
+
+export interface GetFeedbackListResponse {
+  feedbacks: Feedback[];
+}

--- a/src/domains/feedbacks/feedbacks.type.ts
+++ b/src/domains/feedbacks/feedbacks.type.ts
@@ -7,3 +7,7 @@ export interface GetFeedbackListResponse {
 export interface PostFeedBackResponse {
   feedback: Feedback;
 }
+
+export interface PatchFeedBackResponse {
+  feedback: Feedback;
+}

--- a/src/domains/feedbacks/feedbacks.type.ts
+++ b/src/domains/feedbacks/feedbacks.type.ts
@@ -11,3 +11,7 @@ export interface PostFeedBackResponse {
 export interface PatchFeedBackResponse {
   feedback: Feedback;
 }
+
+export interface DeleteFeedBackResponse {
+  feedback: Feedback;
+}

--- a/src/domains/feedbacks/feedbacks.validation.ts
+++ b/src/domains/feedbacks/feedbacks.validation.ts
@@ -1,0 +1,7 @@
+import z from 'zod';
+
+export const GetFeedBackListSchema = z.object({
+  translationId: z.string().uuid({ message: 'traslationId는 uuid' }),
+});
+
+export type GetFeedBackListParams = z.infer<typeof GetFeedBackListSchema>;

--- a/src/domains/feedbacks/feedbacks.validation.ts
+++ b/src/domains/feedbacks/feedbacks.validation.ts
@@ -4,11 +4,15 @@ export const FeedBackSchema = z.object({
   translationId: z.string().uuid({ message: 'traslationId는 uuid' }),
 });
 
+export const ModifyFeedBackSchema = z.object({
+  translationId: z.string().uuid({ message: 'traslationId는 uuid' }),
+  feedbackId: z.string().uuid({ message: 'feedbackId는 uuid' }),
+});
+
 export const PostFeedBackBodySchema = z.object({
-  userId: z.string().uuid({ message: 'userId가 uuid' }),
   content: z.string(),
 });
 
 export type FeedBackParams = z.infer<typeof FeedBackSchema>;
+export type ModifyFeedBackParams = z.infer<typeof ModifyFeedBackSchema>;
 export type PostFeedBackBodyParams = z.infer<typeof PostFeedBackBodySchema>;
-

--- a/src/domains/feedbacks/feedbacks.validation.ts
+++ b/src/domains/feedbacks/feedbacks.validation.ts
@@ -1,7 +1,14 @@
 import z from 'zod';
 
-export const GetFeedBackListSchema = z.object({
+export const FeedBackSchema = z.object({
   translationId: z.string().uuid({ message: 'traslationId는 uuid' }),
 });
 
-export type GetFeedBackListParams = z.infer<typeof GetFeedBackListSchema>;
+export const PostFeedBackBodySchema = z.object({
+  userId: z.string().uuid({ message: 'userId가 uuid' }),
+  content: z.string(),
+});
+
+export type FeedBackParams = z.infer<typeof FeedBackSchema>;
+export type PostFeedBackBodyParams = z.infer<typeof PostFeedBackBodySchema>;
+

--- a/src/domains/routes.ts
+++ b/src/domains/routes.ts
@@ -14,7 +14,7 @@ router.get('/', (req, res) => {
 });
 router.use('/auth', AuthRouter);
 router.use('/challenges', ChallengeRouter);
-router.use('/feedbacks', FeedbackRouter);
+router.use('/translations/:translationId/feedbacks', FeedbackRouter);
 router.use('/notification', NotificationRouter);
 router.use('/likes', LikeRouter);
 //router.use('/translations', TranslationRouter);


### PR DESCRIPTION
## 📌 개요
- 피드백 CRUD API를 구현했습니다.

## ✨ 주요 변경 사항
- 테스트를 위해서 스웨거 문서를 참고해주세요.(테스트 전에 로그인을 하고 해더에 토큰(accessToken)을 넣어줘야 합니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)
- Feedback 스키마 idx가 추가 됨에 따라 seed 파일 수정
- `router.use`를 사용해서 url의 파라미터를 가지고 올때는 Router에 설정 값을 넣어줘야 인식함.
```ts
const router = Router({ mergeParams: true });
```

## 🔗 관련 이슈

#51 

## 📸 스크린샷

