### PR TITLE
[Feature] 관리자, 챌린지 승인, 거절 API

### DIFF
--- a/src/domains/challenges/challenges.routes.ts
+++ b/src/domains/challenges/challenges.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import TranslationRouter from '../translations/translations.routes';
 import ParticipationRouter from '../participants/participants.routes';
+import ChallengesAdminRouter from '../challenges_admin/challenges.admin.routes';
 import ChallengesController from './challenges.controller';
 import { validateRequestData } from '../../middleware/validateRequestData';
 import {
@@ -37,7 +38,10 @@ router.post(
 router.patch(
   '/:challengeId',
   verifyJWTToken,
-  validateRequestData({ params: ChallengeParamsSchema, body: ChallengeBodySchema }),
+  validateRequestData({
+    params: ChallengeParamsSchema,
+    body: ChallengeBodySchema,
+  }),
   ChallengesController.patchChallenge
 ); //챌린지 수정
 router.delete(
@@ -52,8 +56,8 @@ router.get(
   validateRequestData({ params: ChallengeParamsSchema }),
   ChallengesController.getChallenge
 ); //챌린지 상세 조회
-router.patch('/:challengeId/approve'); //챌린지 승인
-router.patch('/:challengeId/reject'); //챌린지 거절
+
+router.use('/:challengeId/admin', ChallengesAdminRouter);
 router.use('/:challengeId/translations', TranslationRouter);
 router.use('/:challengeId/participants', ParticipationRouter);
 

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -1,0 +1,35 @@
+import { PatchController } from '../../types/express';
+import { ChallengeAdminParams } from './challenges.admin.validation';
+import ChallengesAdminService from './challenges.admin.service';
+import { ChallengeAdminResponse } from './challenges.admin.type';
+
+const patchChallengeApprove: PatchController<
+  ChallengeAdminParams,
+  never,
+  ChallengeAdminResponse
+> = async (req, res, next) => {
+  const userRole = req.user?.role;
+
+  if (userRole !== 'ADMIN') {
+    return next({ statusCode: 403, message: '관리자 권한이 없습니다.' });
+  }
+
+  const challengeId = req.params.challengeId;
+
+  const challenge = await ChallengesAdminService.checkChallenge(challengeId);
+
+  if (!challenge) {
+    return next({ statusCode: 404, message: '챌린지를 찾을 수 없습니다.' });
+  }
+
+  const updateChallenge = await ChallengesAdminService.approveChallenge(
+    challengeId
+  );
+
+  res.status(200).json({ challenge: updateChallenge });
+  return;
+};
+
+export default {
+  patchChallengeApprove,
+};

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -158,6 +158,143 @@ const patchChallengeApprove: PatchController<
   return;
 };
 
+/**
+ * @swagger
+ * /api/challenges/{challengeId}/admin/reject:
+ *   patch:
+ *     tags:
+ *       - Challenges Admin
+ *     summary: 관리자 챌린지 거절
+ *     description: 관리자가 챌린지를 거절하는 API
+ *     parameters:
+ *       - in: path
+ *         name: challengeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 챌린지 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - rejectedReason
+ *             properties:
+ *               rejectedReason:
+ *                 type: string
+ *                 description: 챌린지 거절 사유
+ *                 example: "부적절한 내용이 포함되어 있습니다."
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 챌린지 거절 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 challenge:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: "0896ee06-e338-41e4-b006-d7c3fe726bf0"
+ *                     idx:
+ *                       type: number
+ *                       example: 38
+ *                     field:
+ *                       type: string
+ *                       enum: ["CAREER"]
+ *                       example: "CAREER"
+ *                     userId:
+ *                       type: string
+ *                       example: "user-13"
+ *                     title:
+ *                       type: string
+ *                       example: "포트폴리오 작성 팁 문서 번역"
+ *                     originURL:
+ *                       type: string
+ *                       example: "https://example.com/docs/more-12"
+ *                     documentType:
+ *                       type: string
+ *                       enum: ["BLOG"]
+ *                       example: "BLOG"
+ *                     deadline:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-10T00:00:00.000Z"
+ *                     maxParticipants:
+ *                       type: number
+ *                       example: 6
+ *                     currentParticipants:
+ *                       type: number
+ *                       example: 1
+ *                     description:
+ *                       type: string
+ *                       example: "포트폴리오 작성 팁 문서 번역에 대한 협업 번역 챌린지입니다."
+ *                     deletedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       example: null
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-03-25T00:00:00.000Z"
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-02T08:25:14.386Z"
+ *                     deletedReason:
+ *                       type: string
+ *                       nullable: true
+ *                       example: null
+ *                     rejectedReason:
+ *                       type: string
+ *                       example: "부적절한 내용이 포함되어 있습니다."
+ *                     rejectedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-02T08:25:14.386Z"
+ *                     approvalStatus:
+ *                       type: string
+ *                       enum: ["REJECTED"]
+ *                       example: "REJECTED"
+ *                     approvalAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       example: null
+ *                     isParticipantsFull:
+ *                       type: boolean
+ *                       example: false
+ *                     isDeadlineFull:
+ *                       type: boolean
+ *                       example: false
+ *       403:
+ *         description: 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "관리자 권한이 없습니다."
+ *       404:
+ *         description: 챌린지를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "챌린지를 찾을 수 없습니다."
+ */
 const patchChallengeReject: PatchController<
   ChallengeAdminParams,
   ChallengeAdminRejectBody,

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -1,5 +1,8 @@
 import { PatchController } from '../../types/express';
-import { ChallengeAdminParams } from './challenges.admin.validation';
+import {
+  ChallengeAdminParams,
+  ChallengeAdminRejectBody,
+} from './challenges.admin.validation';
 import ChallengesAdminService from './challenges.admin.service';
 import { ChallengeAdminResponse } from './challenges.admin.type';
 
@@ -155,6 +158,36 @@ const patchChallengeApprove: PatchController<
   return;
 };
 
+const patchChallengeReject: PatchController<
+  ChallengeAdminParams,
+  ChallengeAdminRejectBody,
+  ChallengeAdminResponse
+> = async (req, res, next) => {
+  const userRole = req.user?.role;
+
+  if (userRole !== 'ADMIN') {
+    return next({ statusCode: 403, message: '관리자 권한이 없습니다.' });
+  }
+
+  const challengeId = req.params.challengeId;
+  const { rejectedReason } = req.body;
+
+  const challenge = await ChallengesAdminService.checkChallenge(challengeId);
+
+  if (!challenge) {
+    return next({ statusCode: 404, message: '챌린지를 찾을 수 없습니다.' });
+  }
+
+  const updateChallenge = await ChallengesAdminService.rejectChallenge(
+    challengeId,
+    rejectedReason
+  );
+
+  res.status(200).json({ challenge: updateChallenge });
+  return;
+};
+
 export default {
   patchChallengeApprove,
+  patchChallengeReject,
 };

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -3,6 +3,131 @@ import { ChallengeAdminParams } from './challenges.admin.validation';
 import ChallengesAdminService from './challenges.admin.service';
 import { ChallengeAdminResponse } from './challenges.admin.type';
 
+/**
+ * @swagger
+ * /api/challenges/{challengeId}/admin/approve:
+ *   patch:
+ *     tags:
+ *       - Challenges Admin
+ *     summary: 관리자 챌린지 승인
+ *     description: 관리자가 챌린지를 승인하는 API
+ *     parameters:
+ *       - in: path
+ *         name: challengeId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 챌린지 ID
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 챌린지 승인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 challenge:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: "0896ee06-e338-41e4-b006-d7c3fe726bf0"
+ *                     idx:
+ *                       type: number
+ *                       example: 38
+ *                     field:
+ *                       type: string
+ *                       enum: ["CAREER"]
+ *                       example: "CAREER"
+ *                     userId:
+ *                       type: string
+ *                       example: "user-13"
+ *                     title:
+ *                       type: string
+ *                       example: "포트폴리오 작성 팁 문서 번역"
+ *                     originURL:
+ *                       type: string
+ *                       example: "https://example.com/docs/more-12"
+ *                     documentType:
+ *                       type: string
+ *                       enum: ["BLOG"]
+ *                       example: "BLOG"
+ *                     deadline:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-10T00:00:00.000Z"
+ *                     maxParticipants:
+ *                       type: number
+ *                       example: 6
+ *                     currentParticipants:
+ *                       type: number
+ *                       example: 1
+ *                     description:
+ *                       type: string
+ *                       example: "포트폴리오 작성 팁 문서 번역에 대한 협업 번역 챌린지입니다."
+ *                     deletedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       example: null
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-03-25T00:00:00.000Z"
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-02T08:25:14.386Z"
+ *                     deletedReason:
+ *                       type: string
+ *                       nullable: true
+ *                       example: null
+ *                     rejectedReason:
+ *                       type: string
+ *                       nullable: true
+ *                       example: null
+ *                     rejectedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       example: null
+ *                     approvalStatus:
+ *                       type: string
+ *                       enum: ["APPROVED"]
+ *                       example: "APPROVED"
+ *                     approvalAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2025-04-02T08:25:14.386Z"
+ *                     isParticipantsFull:
+ *                       type: boolean
+ *                       example: false
+ *                     isDeadlineFull:
+ *                       type: boolean
+ *                       example: false
+ *       403:
+ *         description: 권한 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "관리자 권한이 없습니다."
+ *       404:
+ *         description: 챌린지를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "챌린지를 찾을 수 없습니다."
+ */
 const patchChallengeApprove: PatchController<
   ChallengeAdminParams,
   never,

--- a/src/domains/challenges_admin/challenges.admin.routes.ts
+++ b/src/domains/challenges_admin/challenges.admin.routes.ts
@@ -2,7 +2,10 @@ import { Router } from 'express';
 import ChallengesAdminController from './challenges.admin.controller';
 import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 import { validateRequestData } from '../../middleware/validateRequestData';
-import { ChallengeAdminParamsSchema } from './challenges.admin.validation';
+import {
+  ChallengeAdminParamsSchema,
+  ChallengeAdminRejectBodySchema,
+} from './challenges.admin.validation';
 const router = Router({ mergeParams: true });
 
 router.use(verifyJWTToken);
@@ -12,7 +15,14 @@ router.patch(
   validateRequestData({ params: ChallengeAdminParamsSchema }),
   ChallengesAdminController.patchChallengeApprove
 ); //챌린지 승인
-router.patch('/reject'); //챌린지 거절
+router.patch(
+  '/reject',
+  validateRequestData({
+    params: ChallengeAdminParamsSchema,
+    body: ChallengeAdminRejectBodySchema,
+  }),
+  ChallengesAdminController.patchChallengeReject
+); //챌린지 거절
 router.patch('/remove'); //챌린지 삭제
 
 export default router;

--- a/src/domains/challenges_admin/challenges.admin.routes.ts
+++ b/src/domains/challenges_admin/challenges.admin.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import ChallengesAdminController from './challenges.admin.controller';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
+import { validateRequestData } from '../../middleware/validateRequestData';
+import { ChallengeAdminParamsSchema } from './challenges.admin.validation';
+const router = Router({ mergeParams: true });
+
+router.use(verifyJWTToken);
+
+router.patch(
+  '/approve',
+  validateRequestData({ params: ChallengeAdminParamsSchema }),
+  ChallengesAdminController.patchChallengeApprove
+); //챌린지 승인
+router.patch('/reject'); //챌린지 거절
+router.patch('/remove'); //챌린지 삭제
+
+export default router;

--- a/src/domains/challenges_admin/challenges.admin.service.ts
+++ b/src/domains/challenges_admin/challenges.admin.service.ts
@@ -22,7 +22,19 @@ const approveChallenge = async (id: string) => {
   return updateChallenge;
 };
 
+const rejectChallenge = async (id: string, rejectedReason: string) => {
+  const updateChallenge = await prisma.challenge.update({
+    where: { id },
+    data: {
+      rejectedReason,
+      approvalStatus: 'REJECTED',
+      rejectedAt: new Date(),
+    },
+  });
+  return updateChallenge;
+};
 export default {
   checkChallenge,
   approveChallenge,
+  rejectChallenge,
 };

--- a/src/domains/challenges_admin/challenges.admin.service.ts
+++ b/src/domains/challenges_admin/challenges.admin.service.ts
@@ -1,0 +1,28 @@
+import prisma from '../../prismaClient';
+
+const checkChallenge = async (id: string) => {
+  const challenge = await prisma.challenge.findUnique({
+    where: {
+      id,
+    },
+  });
+  return challenge;
+};
+
+const approveChallenge = async (id: string) => {
+  const updateChallenge = await prisma.challenge.update({
+    where: {
+      id,
+    },
+    data: {
+      approvalStatus: 'APPROVED',
+      approvalAt: new Date(),
+    },
+  });
+  return updateChallenge;
+};
+
+export default {
+  checkChallenge,
+  approveChallenge,
+};

--- a/src/domains/challenges_admin/challenges.admin.type.ts
+++ b/src/domains/challenges_admin/challenges.admin.type.ts
@@ -1,0 +1,5 @@
+import { Challenge } from '@prisma/client';
+
+export type ChallengeAdminResponse = {
+  challenge: Challenge;
+};

--- a/src/domains/challenges_admin/challenges.admin.validation.ts
+++ b/src/domains/challenges_admin/challenges.admin.validation.ts
@@ -4,4 +4,13 @@ export const ChallengeAdminParamsSchema = z.object({
   challengeId: z.string().uuid({ message: 'id는 uuid 형식이여야 합니다.' }),
 });
 
+export const ChallengeAdminRejectBodySchema = z.object({
+  rejectedReason: z
+    .string()
+    .min(1, { message: '이유는 최소 1글자 이상이어야 합니다.' }),
+});
+
 export type ChallengeAdminParams = z.infer<typeof ChallengeAdminParamsSchema>;
+export type ChallengeAdminRejectBody = z.infer<
+  typeof ChallengeAdminRejectBodySchema
+>;

--- a/src/domains/challenges_admin/challenges.admin.validation.ts
+++ b/src/domains/challenges_admin/challenges.admin.validation.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const ChallengeAdminParamsSchema = z.object({
+  challengeId: z.string().uuid({ message: 'id는 uuid 형식이여야 합니다.' }),
+});
+
+export type ChallengeAdminParams = z.infer<typeof ChallengeAdminParamsSchema>;


### PR DESCRIPTION
## 📌 개요
- 관리자, 챌린지 승인, 거절 API를 구현했습니다.

## ✨ 주요 변경 사항
- domains에 challenges_admin 폴더를 추가했습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

## 🔗 관련 이슈

#62 

## 📸 스크린샷
