### PR TITLE
[FIX] 챌린지 상세 조회 API 수정, 챌린지 생성 검증으로 현재 날짜 이후로만 가능하도록

### DIFF
--- a/src/domains/challenges/challenges.controller.ts
+++ b/src/domains/challenges/challenges.controller.ts
@@ -500,8 +500,8 @@ const getChallengeList: GetController<
  *   get:
  *     tags:
  *       - Challenges
- *     summary: 챌린지 목록 조회
- *     description: 필터 및 정렬 조건을 기반으로 챌린지 목록을 조회합니다.
+ *     summary: 참여중 챌린지 목록 조회
+ *     description: 필터 및 정렬 조건을 기반으로 참여중인 챌린지 목록을 조회합니다.
  *     parameters:
  *       - in: query
  *         name: documentType
@@ -745,6 +745,10 @@ const postChallenge: PostController<
       originURL,
     } = req.body;
     const userId = req.user?.id;
+    if (new Date(deadline) <= new Date()) {
+      next({status:400, message: "마감일자는 현재 날짜 이후부터 가능합니다."});
+      return;
+    }
     const result = await ChallengesService.createChallenge({
       title,
       description,

--- a/src/domains/challenges/challenges.controller.ts
+++ b/src/domains/challenges/challenges.controller.ts
@@ -124,6 +124,7 @@ import {
  *                 deletedReason: null
  *                 rejectedReason: null
  *                 approvalStatus: "PENDING"
+ *                 user: {nickname: "test"}
  *       404:
  *         description: 요청한 리소스를 찾을 수 없습니다.
  *       500:

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -18,6 +18,13 @@ const getChallenge = async (id: string): Promise<GetChallengeResponse> => {
     where: {
       id,
     },
+    include: {
+      user: {
+        select: {
+          nickname: true,
+        }
+      }
+    }
   });
   return { challenge };
 };


### PR DESCRIPTION
## 📌 개요

- 챌린지 상세 조회 API 수정, 챌린지 생성 검증으로 현재 날짜 이후로만 가능하도록

## ✨ 주요 변경 사항

- 챌린지 상세 조회에 닉네임 response 추가

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 챌린지 데이터에 user: { nickname: "닉네임" } 이런 식으로 들어갑니다!

## 🔗 관련 이슈

- #70 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
