### PR TITLE
[Fix] 작업물 생성API 로직 수정

### DIFF
--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -124,7 +124,7 @@ const getTranslationList: GetController<
  *  /api/challenges/{challengeId}/translations:
  *   post:
  *     summary: 번역 작업물 생성 (제출)
- *     description: 사용자가 완성한 번역 작업물을 제출합니다. 인증된 사용자만 번역물을 제출할 수 있으며, 한 챌린지당 하나의 번역물만 제출 가능합니다. 챌린지 상태(승인됨/마감 여부)를 검증하고 참가자 수를 자동으로 증가시킵니다.
+ *     description: 사용자가 특정 챌린지에 번역물을 제출합니다. 한 챌린지당 하나의 번역물만 제출 가능합니다. 챌린지 상태가 APPROVED 일때만 참여가 가능합니다. 생성 후 챌린지의 현재참여자 수를 1 증가시킵니다.
  *     tags: [Translations]
  *     security:
  *       - bearerAuth: []  # 인증 필요 명시

--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -124,8 +124,10 @@ const getTranslationList: GetController<
  *  /api/challenges/{challengeId}/translations:
  *   post:
  *     summary: 번역 작업물 생성 (제출)
- *     description: 사용자가 완성한 번역 작업물을 제출합니다. 챌린지의 참가자 수와 마감 기한을 검사하고, 번역물 생성 시 참가자 수를 자동으로 증가시킵니다.
+ *     description: 사용자가 완성한 번역 작업물을 제출합니다. 인증된 사용자만 번역물을 제출할 수 있으며, 한 챌린지당 하나의 번역물만 제출 가능합니다. 챌린지 상태(승인됨/마감 여부)를 검증하고 참가자 수를 자동으로 증가시킵니다.
  *     tags: [Translations]
+ *     security:
+ *       - bearerAuth: []  # 인증 필요 명시
  *     parameters:
  *       - in: path
  *         name: challengeId
@@ -142,7 +144,6 @@ const getTranslationList: GetController<
  *             required:
  *               - title
  *               - content
- *               - userId
  *             properties:
  *               title:
  *                 type: string
@@ -152,10 +153,6 @@ const getTranslationList: GetController<
  *                 type: string
  *                 description: 번역 작업물 내용
  *                 example: "번역된 내용이 여기에 들어갑니다."
- *               userId:
- *                 type: string
- *                 description: 작업물을 생성한 사용자 ID
- *                 example: "user-12"
  *     responses:
  *       201:
  *         description: 번역 작업물 생성 성공
@@ -197,8 +194,8 @@ const getTranslationList: GetController<
  *                   type: string
  *                   format: date-time
  *                   description: 수정 일시
- *       403:
- *         description: 참가자 수 제한 또는 마감 기한 초과
+ *       401:
+ *         description: 인증 필요
  *         content:
  *           application/json:
  *             schema:
@@ -206,9 +203,19 @@ const getTranslationList: GetController<
  *               properties:
  *                 error:
  *                   type: string
- *                   example: "이 챌린지는 참가자 수 제한으로 인해 더 이상 번역물을 제출할 수 없습니다."
+ *                   example: "인증이 필요합니다. 로그인 후 다시 시도해주세요."
+ *       403:
+ *         description: 접근 거부 (챌린지 상태 문제 또는 중복 제출)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "이 챌린지는 아직 승인 대기 중이므로 번역물을 제출할 수 없습니다."
  *       404:
- *         description: 챌린지 또는 사용자를 찾을 수 없음
+ *         description: 챌린지를 찾을 수 없음
  *         content:
  *           application/json:
  *             schema:
@@ -217,6 +224,16 @@ const getTranslationList: GetController<
  *                 error:
  *                   type: string
  *                   example: "챌린지 ID abc123을 찾을 수 없거나 이미 삭제되었습니다."
+ *       409:
+ *         description: 이미 번역물 제출함
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "이미 이 챌린지에 번역물을 제출하셨습니다. 한 챌린지당 하나의 번역물만 제출할 수 있습니다."
  *       500:
  *         description: 서버 오류
  *         content:
@@ -235,12 +252,20 @@ const postTranslation: PostController<
 > = async (req, res, next) => {
   try {
     const { challengeId } = req.params;
-    const { title, content, userId } = req.body;
+    const { title, content } = req.body;
+
+    // 인증된 사용자 ID 확인
+    const userId = req.user?.id;
+
+    if (!userId) {
+      res.status(403);
+      return;
+    }
 
     const result = await TranslationsService.createTranslation({
       title,
       content,
-      userId,
+      userId, // 미들웨어에서 가져온 사용자 ID 사용
       challengeId,
     });
 

--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -119,12 +119,17 @@ const getTranslationList: GetController<
     next(err);
   }
 };
+//TODO: 번역물 생성시 에러 -  챌린지 상태에 따라 필터링 필요
+//이 챌린지는 참가자 수 제한으로 인해 더 이상 번역물을 제출할 수 없습니다.
+//이 챌린지는 아직 승인 대기 중이므로 번역물을 제출할 수 없습니다.
+//이 챌린지는 이미 종료되었습니다. 번역물을 제출할 수 없습니다.
+//이미 이 챌린지에 번역물을 제출하셨습니다. 한 챌린지당 하나의 번역물만 제출할 수 있습니다.
 /**
  * @swagger
  *  /api/challenges/{challengeId}/translations:
  *   post:
  *     summary: 번역 작업물 생성 (제출)
- *     description: 사용자가 특정 챌린지에 번역물을 제출합니다. 한 챌린지당 하나의 번역물만 제출 가능합니다. 챌린지 상태가 APPROVED 일때만 참여가 가능합니다. 생성 후 챌린지의 현재참여자 수를 1 증가시킵니다.
+ *     description: 사용자가 특정 챌린지에 번역물을 제출합니다. 한 챌린지당 하나의 번역물만 제출 가능합니다. 챌린지 상태가 APPROVED 일때만 참여가 가능합니다. 생성 후 챌린지의 currentParticipants를 1 증가시킵니다.
  *     tags: [Translations]
  *     security:
  *       - bearerAuth: []  # 인증 필요 명시

--- a/src/domains/translations/translations.routes.ts
+++ b/src/domains/translations/translations.routes.ts
@@ -10,6 +10,7 @@ import {
 } from './translations.types';
 import FeedbackRouter from '../feedbacks/feedbacks.routes';
 import LikeRouter from '../likes/likes.routes';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 import TranslationsController from './translations.controller';
 import { UserRole } from '@prisma/client';
 const router = Router({ mergeParams: true });
@@ -25,6 +26,7 @@ router.get(
 
 router.post(
   '/',
+  verifyJWTToken,
   validateRequestData({
     params: TranslationParamsSchema,
     body: TranslationRequestBody,
@@ -42,6 +44,7 @@ router.get(
 // 번역물 수정
 router.patch(
   '/:translationId',
+  verifyJWTToken,
   validateRequestData({
     params: TranslationParamsWithIdSchema,
     body: TranslationUpdateBodySchema,
@@ -51,6 +54,7 @@ router.patch(
 // 번역물 삭제
 router.delete(
   '/:translationId',
+  verifyJWTToken,
   validateRequestData({
     params: TranslationParamsWithIdSchema,
     body: TranslationDeleteBodySchema,

--- a/src/domains/translations/translations.service.ts
+++ b/src/domains/translations/translations.service.ts
@@ -158,7 +158,7 @@ const createTranslation = async ({
   challengeId: string;
 }): Promise<TranslationResponse> => {
   try {
-    // 챌린지 존재 여부 및 상태 확인
+    // 챌린지 존재 여부 및 승인 상태 확인
     const challenge = await prisma.challenge.findUnique({
       where: {
         id: challengeId,
@@ -170,6 +170,7 @@ const createTranslation = async ({
         isDeadlineFull: true,
         maxParticipants: true,
         currentParticipants: true,
+        approvalStatus: true,
       },
     });
 
@@ -179,7 +180,18 @@ const createTranslation = async ({
         `챌린지 ID ${challengeId}를 찾을 수 없거나 이미 삭제되었습니다.`
       );
     }
-
+    if (challenge.approvalStatus !== 'APPROVED') {
+      throw new CustomError(
+        403,
+        `이 챌린지는 ${
+          challenge.approvalStatus === 'PENDING'
+            ? '아직 승인 대기 중이'
+            : challenge.approvalStatus === 'REJECTED'
+            ? '관리자에 의해 승인이 거절되었으'
+            : '관리자에 의해 삭제되었으'
+        } 므로 번역물을 제출할 수 없습니다.`
+      );
+    }
     // 참가자 수 마감 || 기간 마감 확인
     if (challenge.isParticipantsFull || challenge.isDeadlineFull) {
       throw new CustomError(
@@ -187,6 +199,21 @@ const createTranslation = async ({
         `이 챌린지는 ${
           challenge.isParticipantsFull ? '참가자 수 제한' : '마감 기한'
         }으로 인해 더 이상 번역물을 제출할 수 없습니다.`
+      );
+    }
+    // 사용자가 이미 해당 챌린지에 대한 번역을 생성한적있느지 확인
+    const existingTranslation = await prisma.translation.findFirst({
+      where: {
+        challengeId,
+        userId,
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+
+    if (existingTranslation) {
+      throw new Error(
+        '이미 이 챌린지에 번역물을 제출하셨습니다. 한 챌린지당 하나의 번역물만 제출할 수 있습니다.'
       );
     }
 
@@ -332,8 +359,10 @@ const updateTranslation = async ({
       };
     }
 
+    //TODO: 챌린지 마감기한 지났는지 확인 - 지났으면 수정 불가
+
     // 권한 확인 함수사용 - 작성자 본인 또는 관리자만 수정 가능
-    //TODO: 반복 사용되므로 함수로 분리하는게 좋을 듯
+
     const isOwner = translation.userId === userId;
     const isAdmin = userRole === UserRole.ADMIN;
     if (!isOwner && !isAdmin) {
@@ -390,6 +419,7 @@ const updateTranslation = async ({
  * @param userRole 요청한 사용자의 역할 (권한 확인용)
  * @returns 삭제 성공 여부
  */
+//TODO: 챌린지 마감기한 지났는지 확인 - 지났으면 삭제 불가
 const deleteTranslation = async ({
   translationId,
   challengeId,
@@ -425,11 +455,9 @@ const deleteTranslation = async ({
 
     // 승인 상태 확인
     if (challenge.approvalStatus === 'DELETED') {
-      throw new CustomError(
-        400,
-        `이미 삭제된 챌린지의 번역물은 조작할 수 없습니다.`
-      );
+      throw new CustomError(400, `이미 삭제된 챌린지의 번역물입니다.`);
     }
+
     const translation = await prisma.translation.findUnique({
       where: {
         id: translationId,

--- a/src/domains/translations/translations.types.ts
+++ b/src/domains/translations/translations.types.ts
@@ -46,8 +46,6 @@ export const TranslationRequestBody = z.object({
     .refine((val) => val.length >= 1 && val.length <= 1000, {
       message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
     }),
-
-  userId: z.string().min(1, { message: '사용자 ID를 입력해주세요' }),
 });
 
 export type TranslationRequestBody = z.infer<typeof TranslationRequestBody>;


### PR DESCRIPTION
## 📌 개요

- 작업물 생성API 로직 수정하였습니다. 

## ✨ 주요 변경 사항
- req.body 에서 userId 제거하고 JWT 인증 미들웨어 통해 req.user객체에서 받도록 수정
- challengeId 유효한지 (존재하는지), APPROVED 상태인지
- 날짜, 인원 마감 false 인지
- 현재  user가 이 challengeId에 대해 이미 번역물 올린적있는지 (1 챌린지당 1 번역물)

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- #73 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
