### PR TITLE
[Feature] 번역물 수정, 삭제 API 로직 수정 

### DIFF
--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -249,7 +249,7 @@ const getChallengeListByUser = async ({
   keyword,
   userId,
 }: GetChallengeListByUserArgs) => {
-  console.log(userId)
+  console.log(userId);
   const pageNum = Number(page);
   const limitNum = Number(limit);
 

--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -551,10 +551,12 @@ const patchTranslation: PatchController<
 
     const userId = req.user?.id;
     const userRole = req.user?.role;
+
     if (!userId) {
       next(new CustomError(401, '인증이 필요합니다.'));
       return;
     }
+
     const updatedTranslation = await TranslationsService.updateTranslation({
       translationId,
       challengeId,
@@ -565,13 +567,11 @@ const patchTranslation: PatchController<
         content,
       },
     });
+
     res.status(200).send(updatedTranslation);
   } catch (error) {
-<<<<<<< HEAD
+    // 모든 에러를 에러 핸들링 미들웨어로 전달
     next(error);
-=======
-    next(error)
->>>>>>> 77442c71c5f968875f36fcce715a88433f08eef2
   }
 };
 
@@ -681,7 +681,7 @@ const patchTranslation: PatchController<
  */
 const deleteTranslation: DeleteController<
   TranslationParamsWithId,
-  {}, // userId와 userRole은 req.user에서 가져옴
+  {},
   { success: boolean; message?: string }
 > = async (req, res, next) => {
   try {
@@ -706,12 +706,7 @@ const deleteTranslation: DeleteController<
       message: '번역물 삭제 성공',
     });
   } catch (error) {
-<<<<<<< HEAD
     next(error);
-=======
-    // 수정된 코드
-    next(error)
->>>>>>> 77442c71c5f968875f36fcce715a88433f08eef2
   }
 };
 const TranslationsController = {

--- a/src/domains/translations/translations.controller.ts
+++ b/src/domains/translations/translations.controller.ts
@@ -402,8 +402,10 @@ const getTranslationById: GetController<
  *  /api/challenges/{challengeId}/translations/{translationId}:
  *   patch:
  *     summary: 번역물 수정
- *     description: 번역물의 제목과 내용을 수정합니다. 작성자 본인 또는 관리자만 수정할 수 있습니다.
+ *     description: 번역물의 제목과 내용을 수정합니다. 마감기한이 지나지 않은 경우에만 작성자 본인 또는 관리자가 수정할 수 있습니다.
  *     tags: [Translations]
+ *     security:
+ *       - bearerAuth: []  # JWT 인증 필요 명시
  *     parameters:
  *       - in: path
  *         name: challengeId
@@ -423,8 +425,6 @@ const getTranslationById: GetController<
  *         application/json:
  *           schema:
  *             type: object
- *             required:
- *               - userId
  *             properties:
  *               title:
  *                 type: string
@@ -434,15 +434,6 @@ const getTranslationById: GetController<
  *                 type: string
  *                 description: 수정할 내용
  *                 example: "업데이트된 번역 내용이 여기에 포함됩니다."
- *               userId:
- *                 type: string
- *                 description: 요청한 사용자 ID
- *                 example: "user-123"
- *               userRole:
- *                 type: string
- *                 enum: [USER, ADMIN]
- *                 description: 사용자 역할 (권한 확인)
- *                 example: "USER"
  *     responses:
  *       200:
  *         description: 번역물 수정 성공
@@ -460,69 +451,123 @@ const getTranslationById: GetController<
  *                 content:
  *                   type: string
  *                   description: 수정된 내용
- *                 userId:
- *                   type: string
- *                   description: 작성자 ID
- *                 userNickname:
- *                   type: string
- *                   description: 작성자 닉네임
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 작성자 ID
+ *                     nickname:
+ *                       type: string
+ *                       description: 작성자 닉네임
  *                 challengeId:
  *                   type: string
  *                   description: 챌린지 ID
  *                 likeCount:
  *                   type: integer
  *                   description: 좋아요 수
+ *                 createdAt:
+ *                   type: string
+ *                   format: date-time
+ *                   description: 생성 일시
  *                 updatedAt:
  *                   type: string
  *                   format: date-time
  *                   description: 수정 일시
  *       400:
  *         description: 잘못된 요청
- *       403:
- *         description: 권한 없음
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 400
  *                 message:
  *                   type: string
- *                   example: "번역물 수정 권한이 없습니다."
+ *                   example: "수정할 내용을 입력해주세요."
+ *       401:
+ *         description: 인증 필요
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 401
+ *                 message:
+ *                   type: string
+ *                   example: "인증이 필요합니다."
+ *       403:
+ *         description: 권한 없음 또는 마감기한 초과
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 403
+ *                 message:
+ *                   type: string
+ *                   example: "챌린지 마감기한이 지나 수정할 수 없습니다."
  *       404:
  *         description: 번역물 또는 챌린지를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 404
+ *                 message:
+ *                   type: string
+ *                   example: "번역물 ID를 찾을 수 없습니다."
  *       500:
  *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 500
+ *                 message:
+ *                   type: string
+ *                   example: "서버 내부 오류가 발생했습니다."
  */
-const updateTranslation: PatchController<
+const patchTranslation: PatchController<
   TranslationParamsWithId,
   TranslationUpdateBody,
   TranslationResponse
 > = async (req, res, next) => {
   try {
     const { challengeId, translationId } = req.params;
-    const { title, content, userId, userRole } = req.body;
+    const { title, content } = req.body;
 
+    const userId = req.user?.id;
+    const userRole = req.user?.role;
+    if (!userId) {
+      next(new CustomError(401, '인증이 필요합니다.'));
+      return;
+    }
     const updatedTranslation = await TranslationsService.updateTranslation({
       translationId,
       challengeId,
       userId,
-      userRole,
+      userRole: userRole as UserRole,
       updateData: {
         title,
         content,
       },
     });
-
     res.status(200).send(updatedTranslation);
   } catch (error) {
-    if (error instanceof CustomError) {
-      res.status(error.statusCode).send({ error: error.message });
-    } else {
-      res.status(500).send({
-        message:
-          error instanceof Error ? error.message : 'An unknown error occurred',
-      });
-    }
+    next(error);
   }
 };
 
@@ -531,8 +576,10 @@ const updateTranslation: PatchController<
  *  /api/challenges/{challengeId}/translations/{translationId}:
  *   delete:
  *     summary: 번역물 삭제
- *     description: 번역물을 삭제하고 챌린지의 참가자 수를 자동으로 감소시킵니다. 작성자 본인 또는 관리자만 삭제할 수 있습니다.
+ *     description: 번역물을 삭제하고 챌린지의 참가자 수를 자동으로 감소시킵니다. 마감기한이 지나지 않은 경우에만 작성자 본인 또는 관리자가 삭제할 수 있습니다.
  *     tags: [Translations]
+ *     security:
+ *       - bearerAuth: []  # JWT 인증 필요 명시
  *     parameters:
  *       - in: path
  *         name: challengeId
@@ -546,24 +593,6 @@ const updateTranslation: PatchController<
  *         schema:
  *           type: string
  *         description: 삭제할 번역물 ID
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - userId
- *             properties:
- *               userId:
- *                 type: string
- *                 description: 요청한 사용자 ID
- *                 example: "user-123"
- *               userRole:
- *                 type: string
- *                 enum: [USER, ADMIN]
- *                 description: 사용자 역할 (권한 확인)
- *                 example: "USER"
  *     responses:
  *       200:
  *         description: 번역물 삭제 성공
@@ -585,19 +614,40 @@ const updateTranslation: PatchController<
  *             schema:
  *               type: object
  *               properties:
- *                 error:
+ *                 code:
+ *                   type: integer
+ *                   example: 400
+ *                 message:
  *                   type: string
- *                   example: "이미 삭제된 챌린지의 번역물은 조작할 수 없습니다."
- *       403:
- *         description: 권한 없음
+ *                   example: "이미 삭제된 챌린지의 번역물입니다."
+ *       401:
+ *         description: 인증 필요
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 error:
+ *                 code:
+ *                   type: integer
+ *                   example: 401
+ *                 message:
  *                   type: string
- *                   example: "이 번역물에 대한 삭제 권한이 없습니다."
+ *                   example: "인증이 필요합니다."
+ *       403:
+ *         description: 권한 없음 또는 마감기한 초과
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 403
+ *                 message:
+ *                   type: string
+ *                   oneOf:
+ *                     - "이 번역물에 대한 삭제 권한이 없습니다."
+ *                     - "챌린지 마감기한이 지나 삭제할 수 없습니다."
  *       404:
  *         description: 번역물 또는 챌린지를 찾을 수 없음
  *         content:
@@ -605,9 +655,12 @@ const updateTranslation: PatchController<
  *             schema:
  *               type: object
  *               properties:
- *                 error:
+ *                 code:
+ *                   type: integer
+ *                   example: 404
+ *                 message:
  *                   type: string
- *                   example: "번역물 ID abc123을 찾을 수 없거나 이미 삭제되었습니다."
+ *                   example: "번역물 ID를 찾을 수 없거나 이미 삭제되었습니다."
  *       500:
  *         description: 서버 오류
  *         content:
@@ -615,24 +668,33 @@ const updateTranslation: PatchController<
  *             schema:
  *               type: object
  *               properties:
- *                 error:
+ *                 code:
+ *                   type: integer
+ *                   example: 500
+ *                 message:
  *                   type: string
  *                   example: "서버 내부 오류가 발생했습니다."
  */
 const deleteTranslation: DeleteController<
   TranslationParamsWithId,
-  { userId: string; userRole?: UserRole },
+  {}, // userId와 userRole은 req.user에서 가져옴
   { success: boolean; message?: string }
 > = async (req, res, next) => {
   try {
     const { challengeId, translationId } = req.params;
-    const { userId, userRole } = req.body;
+    const userId = req.user?.id;
+    const userRole = req.user?.role;
+
+    if (!userId) {
+      next(new CustomError(401, '인증이 필요합니다.'));
+      return;
+    }
 
     await TranslationsService.deleteTranslation({
       translationId,
       challengeId,
       userId,
-      userRole,
+      userRole: userRole as UserRole,
     });
 
     res.status(200).json({
@@ -640,24 +702,14 @@ const deleteTranslation: DeleteController<
       message: '번역물 삭제 성공',
     });
   } catch (error) {
-    // 수정된 코드
-    if (error instanceof CustomError) {
-      res.status(error.statusCode).send({ error: error.message });
-    } else {
-      res.status(500).send({
-        success: false,
-        message:
-          error instanceof Error ? error.message : 'An unknown error occurred',
-      });
-    }
+    next(error);
   }
 };
-
 const TranslationsController = {
   postTranslation,
   getTranslationList,
   getTranslationById,
-  updateTranslation,
+  patchTranslation,
   deleteTranslation,
 };
 

--- a/src/domains/translations/translations.routes.ts
+++ b/src/domains/translations/translations.routes.ts
@@ -49,7 +49,7 @@ router.patch(
     params: TranslationParamsWithIdSchema,
     body: TranslationUpdateBodySchema,
   }),
-  TranslationsController.updateTranslation as unknown as RequestHandler
+  TranslationsController.patchTranslation as unknown as RequestHandler
 );
 // 번역물 삭제
 router.delete(
@@ -57,7 +57,7 @@ router.delete(
   verifyJWTToken,
   validateRequestData({
     params: TranslationParamsWithIdSchema,
-    body: TranslationDeleteBodySchema,
+    // body: TranslationDeleteBodySchema,
   }),
   TranslationsController.deleteTranslation as unknown as RequestHandler
 );

--- a/src/domains/translations/translations.service.ts
+++ b/src/domains/translations/translations.service.ts
@@ -317,24 +317,25 @@ const updateTranslation = async ({
   };
 }): Promise<TranslationResponse> => {
   try {
-    // Challenge의 유효성 검증
+    // 챌린지 유효성 및 마감기한 확인
     const challenge = await prisma.challenge.findUnique({
       where: {
         id: challengeId,
         deletedAt: null,
       },
-      select: { id: true },
+      select: { isDeadlineFull: true },
     });
 
     if (!challenge) {
-      throw {
-        statusCode: 404,
-        message: `챌린지 ID ${challengeId}를 찾을 수 없거나 이미 삭제되었습니다.`,
-        errorContext: 'challengeLookup',
-      };
+      throw new CustomError(404, '존재하지 않거나 이미 삭제된 챌린지입니다.');
     }
 
-    // Translation의 유효성 검증 및 권한 확인
+    // 마감기한이 지났으면 누구도 수정 불가
+    if (challenge.isDeadlineFull) {
+      throw new CustomError(403, '챌린지 마감기한이 지나 수정할 수 없습니다.');
+    }
+
+    // 번역 유효성 검사
     const translation = await prisma.translation.findUnique({
       where: {
         id: translationId,
@@ -342,31 +343,28 @@ const updateTranslation = async ({
         deletedAt: null,
       },
       include: {
-        user: {
-          select: {
-            id: true, // userId도 조회하여 권한 확인에 사용
-            nickname: true,
-          },
-        },
+        user: { select: { id: true, nickname: true } },
       },
     });
 
     if (!translation) {
-      throw {
-        statusCode: 404,
-        message: `번역물 ID ${translationId}를 찾을 수 없습니다.`,
-        errorContext: 'translationLookup',
-      };
+      throw new CustomError(
+        404,
+        `번역물 ID ${translationId}를 찾을 수 없습니다.`
+      );
     }
 
-    //TODO: 챌린지 마감기한 지났는지 확인 - 지났으면 수정 불가
-
-    // 권한 확인 함수사용 - 작성자 본인 또는 관리자만 수정 가능
-
+    // 작성자 또는 관리자만 수정 가능 (마감기한이 지나지 않은 경우)
     const isOwner = translation.userId === userId;
     const isAdmin = userRole === UserRole.ADMIN;
+
     if (!isOwner && !isAdmin) {
       throw new CustomError(403, '이 번역물에 대한 수정 권한이 없습니다.');
+    }
+
+    // 수정할 데이터가 없는 경우 (제목이나 내용 중 하나는 입력되어야함)
+    if (!updateData.title && !updateData.content) {
+      throw new CustomError(400, '수정할 내용을 입력해주세요.');
     }
 
     const updatedTranslation = await prisma.translation.update({
@@ -386,7 +384,7 @@ const updateTranslation = async ({
       title: updatedTranslation.title,
       content: updatedTranslation.content,
       user: {
-        id: userId,
+        id: translation.user.id,
         nickname: updatedTranslation.user?.nickname || null,
       },
       challengeId: updatedTranslation.challengeId,
@@ -395,22 +393,24 @@ const updateTranslation = async ({
       updatedAt: updatedTranslation.updatedAt,
     };
   } catch (error) {
-    // console.error('번역물 수정 중 오류 발생:', {
-    //   challengeId,
-    //   translationId,
-    //   error,
-    // });
-
-    if (error instanceof CustomError && error.statusCode) {
-      throw error;
+    if (!(error instanceof CustomError)) {
+      console.error('번역물 수정 중 오류 발생:', {
+        translationId,
+        challengeId,
+        error,
+      });
+      throw new CustomError(
+        500,
+        error instanceof Error
+          ? error.message
+          : '서버 내부 오류가 발생했습니다.'
+      );
     }
 
-    throw {
-      statusCode: 500,
-      message: '서버 내부 오류가 발생했습니다.',
-    };
+    throw error;
   }
 };
+
 /**
  * 번역물을 삭제합니다. 작성자 본인 또는 관리자만 삭제할 수 있습니다.
  * @param translationId 삭제할 번역물 ID
@@ -419,7 +419,6 @@ const updateTranslation = async ({
  * @param userRole 요청한 사용자의 역할 (권한 확인용)
  * @returns 삭제 성공 여부
  */
-//TODO: 챌린지 마감기한 지났는지 확인 - 지났으면 삭제 불가
 const deleteTranslation = async ({
   translationId,
   challengeId,
@@ -432,7 +431,6 @@ const deleteTranslation = async ({
   userRole?: UserRole;
 }): Promise<{ success: boolean }> => {
   try {
-    // 챌린지 정보 확인
     const challenge = await prisma.challenge.findUnique({
       where: {
         id: challengeId,
@@ -453,9 +451,13 @@ const deleteTranslation = async ({
       );
     }
 
-    // 승인 상태 확인
     if (challenge.approvalStatus === 'DELETED') {
       throw new CustomError(400, `이미 삭제된 챌린지의 번역물입니다.`);
+    }
+
+    // 마감기한이 지났으면 누구도 삭제 불가
+    if (challenge.isDeadlineFull) {
+      throw new CustomError(403, '챌린지 마감기한이 지나 삭제할 수 없습니다.');
     }
 
     const translation = await prisma.translation.findUnique({
@@ -481,15 +483,7 @@ const deleteTranslation = async ({
       );
     }
 
-    //  권한 확인
-    console.log('권한 검사 정보:', {
-      translationUserId: translation.userId,
-      requestUserId: userId,
-      userRole,
-      isMatch: translation.userId === userId,
-      isAdmin: userRole === UserRole.ADMIN,
-    });
-
+    // 권한 확인 - 작성자 또는 관리자만 삭제 가능
     const isOwner = translation.userId === userId;
     const isAdmin = userRole === UserRole.ADMIN;
 
@@ -505,12 +499,13 @@ const deleteTranslation = async ({
         data: { deletedAt: new Date() },
       });
 
-      // 마감 기한이 지나지 않은 경우에만 참가자 수 관리
+      // 참가자 수 관리
+      // 마감 기한이 지나지 않은 경우, 참가자수 - 1
+
       if (!challenge.isDeadlineFull) {
         if (challenge.currentParticipants > 0) {
           const newParticipantCount = challenge.currentParticipants - 1;
 
-          // 챌린지 정보 업데이트
           await prismaClient.challenge.update({
             where: { id: challengeId },
             data: {
@@ -518,14 +513,6 @@ const deleteTranslation = async ({
               isParticipantsFull: false, // 번역물 삭제 후에는 항상 false
             },
           });
-
-          // console.log(
-          //   `챌린지 ID ${challengeId}의 참가자 수 업데이트: ${
-          //     challenge.currentParticipants
-          //   } -> ${newParticipantCount}, 상태: ${
-          //     challenge.isParticipantsFull ? '가득참' : '여유있음'
-          //   } -> 여유있음`
-          // );
         }
       }
     });

--- a/src/domains/translations/translations.types.ts
+++ b/src/domains/translations/translations.types.ts
@@ -64,12 +64,6 @@ export const TranslationUpdateBodySchema = z.object({
     .refine((val) => val.length >= 1 && val.length <= 1000, {
       message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
     }),
-  userId: z.string().min(1, { message: '사용자 ID는 필수 항목입니다.' }),
-  userRole: z
-    .nativeEnum(UserRole, {
-      errorMap: () => ({ message: '유효한 UserRole이 아닙니다.' }),
-    })
-    .optional(),
 });
 
 // 번역물 수정 요청 바디 타입


### PR DESCRIPTION
## 📌 개요

-  번역물 수정, 삭제 API 로직 수정 

## ✨ 주요 변경 사항

- 챌린지의 마감기한이 지나지 않았을 경우 작성자나 관리자는 번역물 수정, 삭제가 가능합니다.
- 마감기한이 지나면 누구도 수정, 삭제가 불가능합니다. 
- userId, userRole을 jwt 미들웨어에서 받아와서 처리하도록 수정했습니다. 

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- #88 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
