### PR TITLE
Feat: 작업물 추천 해제 API 구현

### DIFF
--- a/prisma/schema/Like.prisma
+++ b/prisma/schema/Like.prisma
@@ -5,5 +5,6 @@ model Like {
   userId        String
   user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, translationId])
   @@map("likes")
 }

--- a/src/domains/likes/likes.controller.ts
+++ b/src/domains/likes/likes.controller.ts
@@ -1,0 +1,172 @@
+import { DeleteController, PostController } from '../../types/express';
+import likesService from './likes.service';
+import { LikeResponse } from './likes.types';
+import { LikeRequestParams } from './likes.validation';
+
+/**
+ * @swagger
+ * /api/translations/{translationId}/like:
+ *   post:
+ *     tags:
+ *       - Likes
+ *     summary: 작업물 추천
+ *     description: 특정 번역 작업물에 대해 추천(좋아요)을 등록합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 추천할 번역 작업물의 ID
+ *         schema:
+ *           type: string
+ *     responses:
+ *       201:
+ *         description: 추천 등록 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 like:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 추천 ID
+ *                     translationId:
+ *                       type: string
+ *                       description: 번역 작업물 ID
+ *                     userId:
+ *                       type: string
+ *                       description: 추천한 사용자 ID
+ *             example:
+ *               like:
+ *                 id: "123e4567-e89b-12d3-a456-426614174000"
+ *                 translationId: "02f43933-41fb-4dd5-8426-700f17beb6fa"
+ *                 userId: "user-1"
+ *       400:
+ *         description: 존재하지 않는 번역물이거나 이미 추천한 작업물입니다.
+ *       401:
+ *         description: 인증되지 않은 사용자
+ *       500:
+ *         description: 서버 오류
+ */
+const postLike: PostController<LikeRequestParams, never, LikeResponse> = async (
+  req,
+  res,
+  next
+) => {
+  const translationId = req.params.translationId;
+  const userId = req.user?.id ?? '';
+  console.log('userId', userId);
+
+  // 존재하는 번역물인지 확인
+  const translation = await likesService.checkTranslation(translationId);
+
+  if (!translation) {
+    return next({ statusCode: 400, message: '존재하지 않는 번역물입니다.' });
+  }
+
+  // 이미 좋아요를 눌렀는지 확인
+  const existingLike = await likesService.checkExistingLike(
+    translationId,
+    userId
+  );
+
+  if (existingLike) {
+    return next({ statusCode: 400, message: '이미 좋아요를 눌렀습니다.' });
+  }
+
+  // 좋아요 생성, 번역 좋아요 수 1 증가
+  const like = await likesService.createLikeAndPlusTranslationLikeCount(
+    translationId,
+    userId
+  );
+
+  res.status(201).json({ like });
+};
+
+/**
+ * @swagger
+ * /api/translations/{translationId}/like:
+ *   delete:
+ *     tags:
+ *       - Likes
+ *     summary: 작업물 추천 취소
+ *     description: 특정 번역 작업물에 대한 추천(좋아요)을 취소합니다.
+ *     parameters:
+ *       - in: path
+ *         name: translationId
+ *         required: true
+ *         description: 추천을 취소할 번역 작업물의 ID
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 추천 취소 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 like:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 취소된 추천 ID
+ *                     translationId:
+ *                       type: string
+ *                       description: 번역 작업물 ID
+ *                     userId:
+ *                       type: string
+ *                       description: 추천을 취소한 사용자 ID
+ *             example:
+ *               like:
+ *                 id: "123e4567-e89b-12d3-a456-426614174000"
+ *                 translationId: "02f43933-41fb-4dd5-8426-700f17beb6fa"
+ *                 userId: "user-1"
+ *       400:
+ *         description: 존재하지 않는 번역물이거나 추천하지 않은 작업물입니다.
+ *       401:
+ *         description: 인증되지 않은 사용자
+ *       500:
+ *         description: 서버 오류
+ */
+const deleteLike: DeleteController<
+  LikeRequestParams,
+  never,
+  LikeResponse
+> = async (req, res, next) => {
+  const translationId = req.params.translationId;
+  const userId = req.user?.id ?? '';
+
+  const translation = await likesService.checkTranslation(translationId);
+
+  if (!translation) {
+    return next({ statusCode: 400, message: '존재하지 않는 번역물입니다.' });
+  }
+
+  const existingLike = await likesService.checkExistingLike(
+    translationId,
+    userId
+  );
+
+  if (!existingLike) {
+    return next({ statusCode: 400, message: '좋아요를 누르지 않았습니다.' });
+  }
+
+  const likeId = existingLike.id;
+
+  // 좋아요 삭제, 번역 좋아요 수 1 감소
+  const deletedLike = await likesService.deleteLikeAndMinusTranslationLikeCount(
+    likeId,
+    translationId
+  );
+
+  res.status(200).json({ like: deletedLike });
+};
+
+export default {
+  postLike,
+  deleteLike,
+};

--- a/src/domains/likes/likes.routes.ts
+++ b/src/domains/likes/likes.routes.ts
@@ -1,8 +1,12 @@
-import { Router } from "express";
+import { Router } from 'express';
+import likesController from './likes.controller';
+import { verifyJWTToken } from '../../middleware/verifyJWTToken';
 
-const router = Router();
+const router = Router({ mergeParams: true });
 
-router.post("/"); // 작업물 추천하기
-router.delete("/"); // 작업물 추천 해제하기
+router.use(verifyJWTToken);
+
+router.post('/like', likesController.postLike);
+router.delete('/like', likesController.deleteLike);
 
 export default router;

--- a/src/domains/likes/likes.service.ts
+++ b/src/domains/likes/likes.service.ts
@@ -1,0 +1,103 @@
+import prisma from '../../prismaClient';
+import { PrismaClient } from '@prisma/client';
+
+type TransactionClient = Omit<
+  PrismaClient,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
+>;
+
+const checkTranslation = async (translationId: string) => {
+  const translation = await prisma.translation.findUnique({
+    where: { id: translationId },
+  });
+
+  return translation;
+};
+
+const checkExistingLike = async (translationId: string, userId: string) => {
+  const existingLike = await prisma.like.findFirst({
+    where: {
+      AND: [{ userId }, { translationId }],
+    },
+  });
+
+  return existingLike;
+};
+
+const createLike = async (
+  translationId: string,
+  userId: string,
+  client: PrismaClient | TransactionClient = prisma
+) => {
+  const like = await client.like.create({
+    data: { translationId, userId },
+  });
+
+  return like;
+};
+
+const deleteLike = async (
+  likeId: string,
+  client: PrismaClient | TransactionClient = prisma
+) => {
+  const deletedLike = await client.like.delete({
+    where: { id: likeId },
+  });
+
+  return deletedLike;
+};
+
+const setTranslationLikeCount = async (
+  translationId: string,
+  isPlus: boolean,
+  client: PrismaClient | TransactionClient = prisma
+) => {
+  const translation = await client.translation.update({
+    where: {
+      id: translationId,
+    },
+    data: {
+      likeCount: {
+        increment: isPlus ? 1 : -1,
+      },
+    },
+  });
+
+  return translation;
+};
+
+const createLikeAndPlusTranslationLikeCount = async (
+  translationId: string,
+  userId: string
+) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const like = await createLike(translationId, userId, tx);
+    await setTranslationLikeCount(translationId, true, tx);
+    return like;
+  });
+
+  return result;
+};
+
+const deleteLikeAndMinusTranslationLikeCount = async (
+  likeId: string,
+  translationId: string
+) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const like = await deleteLike(likeId, tx);
+    await setTranslationLikeCount(translationId, false, tx);
+    return like;
+  });
+
+  return result;
+};
+
+export default {
+  checkTranslation,
+  checkExistingLike,
+  createLike,
+  deleteLike,
+  setTranslationLikeCount,
+  createLikeAndPlusTranslationLikeCount,
+  deleteLikeAndMinusTranslationLikeCount,
+};

--- a/src/domains/likes/likes.types.ts
+++ b/src/domains/likes/likes.types.ts
@@ -1,0 +1,5 @@
+import { Like } from '@prisma/client';
+
+export interface LikeResponse {
+  like: Like;
+}

--- a/src/domains/likes/likes.validation.ts
+++ b/src/domains/likes/likes.validation.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const LikeParamsSchema = z.object({
+  translationId: z.string().uuid({ message: 'id는 uuid 형식이여야 합니다.' }),
+});
+
+export type LikeRequestParams = z.infer<typeof LikeParamsSchema>;

--- a/src/domains/routes.ts
+++ b/src/domains/routes.ts
@@ -16,8 +16,7 @@ router.use('/auth', AuthRouter);
 router.use('/challenges', ChallengeRouter);
 router.use('/translations/:translationId/feedbacks', FeedbackRouter);
 router.use('/notification', NotificationRouter);
-router.use('/likes', LikeRouter);
-//router.use('/translations', TranslationRouter);
 router.use('/users', UserRouter);
+router.use('/translations/:translationId', LikeRouter);
 
 export default router;

--- a/src/domains/translations/translations.routes.ts
+++ b/src/domains/translations/translations.routes.ts
@@ -65,6 +65,5 @@ router.delete(
 router.post('/draftedTranslations'); // 작업물 임시 저장
 router.get('/draftedTranslations'); // 작업물 임시 저장 가져오기
 router.use('/:translationId/feedbacks', FeedbackRouter);
-router.use('/:translationId', LikeRouter);
 
 export default router;


### PR DESCRIPTION
## 📌 개요
작업물 추천, 해제 API 구현

## ✨ 주요 변경 사항
- 스웨거 문서를 참고해주세요!


## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)
- 작업물 ID와 유저 ID로 Like을 식별하기 위해서 유니크를 추가했습니다.
```
@@unique([userId, translationId])
```
- 좋아요를 추가하거나 해제하면 translations 테이블에 `likeCount`도 변경되어야 해서 트랜잭션으로 처리했습니다.
## 🔗 관련 이슈

#92

## 📸 스크린샷

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/7abd3361-bd8a-4c34-bc17-1d32417ccd22" />

