### PR TITLE
[Feat] 액세스토큰, 리프레시토큰 쿠키 설정 & 로그아웃 API 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ app.use(morgan('dev'));
 app.use(
   cors({
     origin: process.env.CLIENT_URL,
+    credentials: true,
     exposedHeaders: ['Authorization'],
   })
 );

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -176,11 +176,11 @@ const login = async (req: Request, res: Response, next: NextFunction) => {
 
   const accessToken = jwtUtils.createToken(existedUser, 'access');
   const refreshToken = jwtUtils.createToken(existedUser, 'refresh');
-  await AuthService.saveRefreshToken(existedUser.email, refreshToken);
+  await AuthService.saveRefreshToken(existedUser.email, refreshToken); //  refreshToken DB에 저장 -> 로그아웃 시 삭제 필요
 
   res.set('Authorization', `Bearer ${accessToken}`);
   res.cookie('accessToken', accessToken, {
-    httpOnly: false, // 프론트에서 document.cookie로 접근할 수 있게 하려면 false
+    httpOnly: false, // 프론트에서 document.cookie로 접근할 수 있게 false
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
   });
@@ -194,10 +194,80 @@ const login = async (req: Request, res: Response, next: NextFunction) => {
 
   res.status(200).json({
     user: restUser,
+    accessToken,
   });
+};
+/**
+ * @swagger
+ * /api/auth/logout:
+ *   post:
+ *     summary: 로그아웃
+ *     description: 사용자의 액세스 토큰과 리프레시 토큰을 제거하여 로그아웃합니다.
+ *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []  # JWT 인증 필요 명시
+ *     responses:
+ *       200:
+ *         description: 로그아웃 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 로그아웃 완료
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 401
+ *                 message:
+ *                   type: string
+ *                   example: 인증이 필요합니다.
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   example: 500
+ *                 message:
+ *                   type: string
+ *                   example: 로그아웃 처리 중 오류 발생
+ */
+
+// 쿠키에서 refreshToken 제거 위해 로그아웃 API 추가
+const logout = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    res.clearCookie('refreshToken', {
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true,
+    });
+
+    // accessToken도 제거
+    res.clearCookie('accessToken', {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    });
+    res.status(200).json({ message: '로그아웃 완료' });
+  } catch (err) {
+    next({ statusCode: 500, message: '로그아웃 처리 중 오류 발생' });
+  }
 };
 
 export default {
   signup,
   login,
+  logout,
 };

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -179,6 +179,11 @@ const login = async (req: Request, res: Response, next: NextFunction) => {
   await AuthService.saveRefreshToken(existedUser.email, refreshToken);
 
   res.set('Authorization', `Bearer ${accessToken}`);
+  res.cookie('accessToken', accessToken, {
+    httpOnly: false, // 프론트에서 document.cookie로 접근할 수 있게 하려면 false
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
   res.cookie('refreshToken', refreshToken, {
     httpOnly: true,
     sameSite: 'none',

--- a/src/domains/auth/auth.routes.ts
+++ b/src/domains/auth/auth.routes.ts
@@ -25,7 +25,7 @@ router.post(
   authController.login
 ); // 로그인
 
-router.post('/logout'); //로그아웃
+router.post('/logout', authController.logout); //로그아웃
 
 // TODO: 테스트 용 api, 삭제 예정
 router.post(

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -35,7 +35,6 @@ const getChallengeList = async ({
   keyword,
   page,
   limit,
-  status,
 }: ChallengeRequestQueries) => {
   const pageNum = Number(page);
   const limitNum = Number(limit);
@@ -54,24 +53,10 @@ const getChallengeList = async ({
         documentType: documentType || undefined,
         field: fieldCondition || undefined,
         approvalStatus: 'APPROVED',
-        ...(status === 'running' && {
-          isParticipantsFull: false,
-          isDeadlineFull: false,
-        }),
-        ...(status === 'end' && {
-          OR: [
-            { isParticipantsFull: true },
-            { isDeadlineFull: true },
-          ],
-        }),
         ...(keyword && {
-          AND: [
-            {
-              OR: [
-                { title: { contains: keyword, mode: 'insensitive' } },
-                { description: { contains: keyword, mode: 'insensitive' } },
-              ],
-            },
+          OR: [
+            { title: { contains: keyword, mode: 'insensitive' } },
+            { description: { contains: keyword, mode: 'insensitive' } },
           ],
         }),
       },
@@ -95,24 +80,10 @@ const getChallengeList = async ({
         documentType: documentType || undefined,
         field: fieldCondition || undefined,
         approvalStatus: 'APPROVED',
-        ...(status === 'running' && {
-          isParticipantsFull: false,
-          isDeadlineFull: false,
-        }),
-        ...(status === 'end' && {
-          OR: [
-            { isParticipantsFull: true },
-            { isDeadlineFull: true },
-          ],
-        }),
         ...(keyword && {
-          AND: [
-            {
-              OR: [
-                { title: { contains: keyword, mode: 'insensitive' } },
-                { description: { contains: keyword, mode: 'insensitive' } },
-              ],
-            },
+          OR: [
+            { title: { contains: keyword, mode: 'insensitive' } },
+            { description: { contains: keyword, mode: 'insensitive' } },
           ],
         }),
       },
@@ -132,6 +103,7 @@ const getChallengeListParticipating = async ({
   const pageNum = Number(page);
   const limitNum = Number(limit);
   const successBoolean = isExpired === 'true';
+
   const skip = (pageNum - 1) * limitNum;
 
   const [challenges, totalCount] = await Promise.all([
@@ -164,14 +136,6 @@ const getChallengeListParticipating = async ({
         documentType: true,
         isParticipantsFull: true,
         isDeadlineFull: true,
-        translations: {
-          where: {
-            userId,
-          },
-          select: {
-            id: true,
-          }
-        }
       },
     }),
     prisma.challenge.count({
@@ -212,11 +176,11 @@ const getChallengeListByAdmin = async ({
     const orderCondition: Prisma.ChallengeOrderByWithRelationInput = {};
 
     switch (orderBy) {
-      case Order.createdFirst:
-        orderCondition.createdAt = 'asc'; // 신청 빠른 순
-        break;
       case Order.createdLast:
-        orderCondition.createdAt = 'desc'; // 신청 느린 순
+        orderCondition.createdAt = 'asc'; // 신청 오래된 순
+        break;
+      case Order.createdFirst:
+        orderCondition.createdAt = 'desc'; // 신청 최신 순
         break;
       case Order.deadLineFirst:
         orderCondition.deadline = 'asc'; // 마감일 빠른 순
@@ -295,11 +259,11 @@ const getChallengeListByUser = async ({
     const orderCondition: Prisma.ChallengeOrderByWithRelationInput = {};
 
     switch (orderBy) {
-      case Order.createdFirst:
-        orderCondition.createdAt = 'asc'; // 신청 빠른 순
-        break;
       case Order.createdLast:
-        orderCondition.createdAt = 'desc'; // 신청 느린 순
+        orderCondition.createdAt = 'asc'; // 신청 오래된 순
+        break;
+      case Order.createdFirst:
+        orderCondition.createdAt = 'desc'; // 신청 최신 순
         break;
       case Order.deadLineFirst:
         orderCondition.deadline = 'asc'; // 마감일 빠른 순

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -35,6 +35,7 @@ const getChallengeList = async ({
   keyword,
   page,
   limit,
+  status,
 }: ChallengeRequestQueries) => {
   const pageNum = Number(page);
   const limitNum = Number(limit);
@@ -53,10 +54,21 @@ const getChallengeList = async ({
         documentType: documentType || undefined,
         field: fieldCondition || undefined,
         approvalStatus: 'APPROVED',
+        ...(status === 'running' && {
+          isParticipantsFull: false,
+          isDeadlineFull: false,
+        }),
+        ...(status === 'end' && {
+          OR: [{ isParticipantsFull: true }, { isDeadlineFull: true }],
+        }),
         ...(keyword && {
-          OR: [
-            { title: { contains: keyword, mode: 'insensitive' } },
-            { description: { contains: keyword, mode: 'insensitive' } },
+          AND: [
+            {
+              OR: [
+                { title: { contains: keyword, mode: 'insensitive' } },
+                { description: { contains: keyword, mode: 'insensitive' } },
+              ],
+            },
           ],
         }),
       },
@@ -80,10 +92,21 @@ const getChallengeList = async ({
         documentType: documentType || undefined,
         field: fieldCondition || undefined,
         approvalStatus: 'APPROVED',
+        ...(status === 'running' && {
+          isParticipantsFull: false,
+          isDeadlineFull: false,
+        }),
+        ...(status === 'end' && {
+          OR: [{ isParticipantsFull: true }, { isDeadlineFull: true }],
+        }),
         ...(keyword && {
-          OR: [
-            { title: { contains: keyword, mode: 'insensitive' } },
-            { description: { contains: keyword, mode: 'insensitive' } },
+          AND: [
+            {
+              OR: [
+                { title: { contains: keyword, mode: 'insensitive' } },
+                { description: { contains: keyword, mode: 'insensitive' } },
+              ],
+            },
           ],
         }),
       },
@@ -103,7 +126,6 @@ const getChallengeListParticipating = async ({
   const pageNum = Number(page);
   const limitNum = Number(limit);
   const successBoolean = isExpired === 'true';
-
   const skip = (pageNum - 1) * limitNum;
 
   const [challenges, totalCount] = await Promise.all([
@@ -136,6 +158,14 @@ const getChallengeListParticipating = async ({
         documentType: true,
         isParticipantsFull: true,
         isDeadlineFull: true,
+        translations: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+          },
+        },
       },
     }),
     prisma.challenge.count({
@@ -176,11 +206,11 @@ const getChallengeListByAdmin = async ({
     const orderCondition: Prisma.ChallengeOrderByWithRelationInput = {};
 
     switch (orderBy) {
-      case Order.createdLast:
-        orderCondition.createdAt = 'asc'; // 신청 오래된 순
-        break;
       case Order.createdFirst:
-        orderCondition.createdAt = 'desc'; // 신청 최신 순
+        orderCondition.createdAt = 'asc'; // 신청 빠른 순
+        break;
+      case Order.createdLast:
+        orderCondition.createdAt = 'desc'; // 신청 느린 순
         break;
       case Order.deadLineFirst:
         orderCondition.deadline = 'asc'; // 마감일 빠른 순
@@ -259,11 +289,11 @@ const getChallengeListByUser = async ({
     const orderCondition: Prisma.ChallengeOrderByWithRelationInput = {};
 
     switch (orderBy) {
-      case Order.createdLast:
-        orderCondition.createdAt = 'asc'; // 신청 오래된 순
-        break;
       case Order.createdFirst:
-        orderCondition.createdAt = 'desc'; // 신청 최신 순
+        orderCondition.createdAt = 'asc'; // 신청 빠른 순
+        break;
+      case Order.createdLast:
+        orderCondition.createdAt = 'desc'; // 신청 느린 순
         break;
       case Order.deadLineFirst:
         orderCondition.deadline = 'asc'; // 마감일 빠른 순

--- a/src/middleware/verifyJWTToken.ts
+++ b/src/middleware/verifyJWTToken.ts
@@ -8,37 +8,61 @@ export const verifyJWTToken = async (
   next: NextFunction
 ) => {
   try {
+    let accessToken: string | undefined;
+
+    // 헤더에서 토큰 확인
     const authorization = req.headers.authorization;
-    if (!authorization?.startsWith('Bearer ')) {
-      return next({ statusCode: 401, message: 'Bearer 없음.' });
+    if (authorization?.startsWith('Bearer ')) {
+      accessToken = authorization.split(' ')[1];
     }
 
-    const accessToken = authorization.split(' ')[1];
-    const payloadAccess = jwt.verifyToken(accessToken);
+    // 쿠키에서 토큰 확인 (헤더에 없는 경우)
+    if (!accessToken && req.cookies?.accessToken) {
+      accessToken = req.cookies.accessToken;
+    }
 
+    // 토큰이 없는 경우
+    if (!accessToken) {
+      return next({ statusCode: 401, message: '액세스 토큰이 없습니다.' });
+    }
+
+    //액세스 토큰 검증
+    const payloadAccess = jwt.verifyToken(accessToken, 'access');
     if (payloadAccess) {
       req.user = payloadAccess;
       return next();
     }
 
-    const refreshToken = req.cookies.refreshToken;
+    // 액세스 토큰이 만료되면 리프레시 토큰으로 갱신
+    const refreshToken = req.cookies?.refreshToken;
     if (!refreshToken) {
-      return next({ statusCode: 401, message: 'refreshToken 없음' });
+      return next({
+        statusCode: 401,
+        message: '리프레시 토큰이 없습니다. 다시 로그인해주세요.',
+      });
     }
 
-    const payloadRefresh = jwt.verifyToken(refreshToken);
+    const payloadRefresh = jwt.verifyToken(refreshToken, 'refresh');
     if (!payloadRefresh) {
-      return next({ statusCode: 401, message: 'refreshToken 만료' });
+      return next({
+        statusCode: 401,
+        message: '리프레시 토큰이 만료되었습니다. 다시 로그인해주세요.',
+      });
     }
 
+    //저장된 리프레시 토큰과 비교
     const savedRefreshToken = await AuthService.getRefreshToken(
       payloadRefresh.id
     );
-    // 굳이 있어야 되나 싶음..
+
     if (savedRefreshToken !== refreshToken) {
-      return next({ statusCode: 401, message: '저장된 refreshToken 불일치' });
+      return next({
+        statusCode: 401,
+        message: '유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요.',
+      });
     }
 
+    // 새 토큰 발급
     const newUserInfo = {
       id: payloadRefresh.id,
       role: payloadRefresh.role,
@@ -49,9 +73,18 @@ export const verifyJWTToken = async (
 
     await AuthService.updateRefreshToken(payloadRefresh.id, newRefreshToken);
 
+    // 헤더에 새 액세스 토큰 설정
     res.set('Authorization', `Bearer ${newAccessToken}`);
+
+    // 쿠키 설정
+    res.cookie('accessToken', newAccessToken, {
+      httpOnly: false, // 프론트엔드에서 접근 가능하게 false
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    });
+
     res.cookie('refreshToken', newRefreshToken, {
-      httpOnly: true,
+      httpOnly: true, // JS에서 접근 불가
       sameSite: 'none',
       secure: true,
     });
@@ -59,6 +92,7 @@ export const verifyJWTToken = async (
     req.user = newUserInfo;
     next();
   } catch (error) {
-    next({ statusCode: 500, message: '인증 처리 중 오류 발생' });
+    console.error('JWT 검증 오류:', error);
+    next({ statusCode: 500, message: '인증 처리 중 오류가 발생했습니다.' });
   }
 };

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -4,9 +4,8 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 interface CustomJwtPayload extends JwtPayload {
   id: string;
   role: 'USER' | 'ADMIN';
+  tokenType: 'access' | 'refresh';
 }
-
-const secretKey = process.env.JWT_SECRET_KEY || 'secret';
 
 const createToken = (
   user: { id: string; role: 'USER' | 'ADMIN' },
@@ -15,14 +14,47 @@ const createToken = (
   const payload = {
     id: user.id,
     role: user.role,
+    tokenType,
   };
-  const expiresIn = tokenType === 'access' ? '10m' : '1h';
-  return jwt.sign(payload, secretKey, { expiresIn });
+
+  const expiresIn = tokenType === 'access' ? '10m' : '1d';
+  const secret =
+    tokenType === 'access'
+      ? process.env.JWT_ACCESS_SECRET || 'access-secret'
+      : process.env.JWT_REFRESH_SECRET || 'refresh-secret';
+
+  console.log(
+    '🧪 JWT_ACCESS_SECRET from process.env:',
+    process.env.JWT_ACCESS_SECRET
+  );
+  console.log(
+    '🧪 JWT_REFRESH_SECRET from process.env:',
+    process.env.JWT_REFRESH_SECRET
+  );
+
+  return jwt.sign(payload, secret, { expiresIn });
 };
 
-const verifyToken = (token: string): CustomJwtPayload | null => {
+const verifyToken = (
+  token: string,
+  tokenType: 'access' | 'refresh'
+): CustomJwtPayload | null => {
   try {
-    const payload = jwt.verify(token, secretKey) as CustomJwtPayload;
+    const secret =
+      tokenType === 'access'
+        ? process.env.JWT_ACCESS_SECRET || 'access-secret'
+        : process.env.JWT_REFRESH_SECRET || 'refresh-secret';
+    console.log('🔍 token:', token);
+    console.log('🔍 tokenType:', tokenType);
+    console.log('🔍 secret:', secret);
+
+    const payload = jwt.verify(token, secret) as CustomJwtPayload;
+
+    // 토큰이 실제 의도된 타입인지
+    if (payload.tokenType !== tokenType) {
+      return null;
+    }
+
     return payload;
   } catch (error) {
     return null;


### PR DESCRIPTION
## 📌 개요

- 액세스토큰, 리프레시토큰 쿠키 설정 & 로그아웃 API 구

## ✨ 주요 변경 사항

- 10분 간격으로 access 토큰 만료되어서 로그인 지속을 위해 refresh 토큰 설정 및 access 토큰 갱신 구현
- 프론트에서 middleware.ts에서 인증 확인을 위해서 쿠키에 엑세스토큰이 필요
- 로그아웃시 쿠키에 있는 refresh 토큰 제거를 위해서 로그아웃 API 추가

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- access 토큰과 refresh 토큰 시크릿키를 분리하기 위해 기존에 승우님이 알려주셨던 JWT_SECRET_KEY키를 access 토큰키로 설정하고, refresh 용 비밀키를 .env에 추가했습니다. 각각 JWT_ACCESS_SECRET 와 JWT_REFRESH_SECRET로 환경변수명 수정이 있었어서 노션 참고해서 .env 파일 수정 부탁드리겠습니다. 
- 로그인 시 로컬스토리지와 쿠키에 엑세스토큰 과 리프레시토큰이 저장되고 로그아웃시 모두 삭제되는 것을 테스트하였습니다. 관련사항 노션에 정리해두었습니다. https://www.notion.so/1cf36713bdaf8098be08d809d61e88f7?pvs=4

## 🔗 관련 이슈

- #98 

