### PR TITLE
feat: nextChallengeId, prevChallengeId 추가 (챌린지 상세조회)

### DIFF
--- a/src/domains/challenges/challenges.controller.ts
+++ b/src/domains/challenges/challenges.controller.ts
@@ -125,6 +125,8 @@ import {
  *                 rejectedReason: null
  *                 approvalStatus: "PENDING"
  *                 user: {nickname: "test"}
+ *                 nextChallengeId: {id: "uuid"}
+ *                 prevChallengeId: {id: "uuid"}
  *       404:
  *         description: 요청한 리소스를 찾을 수 없습니다.
  *       500:

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -5,6 +5,7 @@ import {
   GetChallengeListByUserArgs,
   GetChallengeListParticipating,
   GetChallengeResponse,
+  GetChallengeResponseWithNextAndPrev,
   Order,
   UpdateChallengeArgs,
 } from './challenges.type';
@@ -13,7 +14,7 @@ import {
   ChallengeRequestQueries,
 } from './challenges.validation';
 
-const getChallenge = async (id: string): Promise<GetChallengeResponse> => {
+const getChallenge = async (id: string): Promise<GetChallengeResponseWithNextAndPrev> => {
   const challenge = await prisma.challenge.findUnique({
     where: {
       id,
@@ -26,7 +27,28 @@ const getChallenge = async (id: string): Promise<GetChallengeResponse> => {
       },
     },
   });
-  return { challenge };
+
+  const prevChallengeId = await prisma.challenge.findFirst({
+    where: {
+      createdAt: { lt: challenge?.createdAt},
+    },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+    }
+  })
+
+  const nextChallengeId = await prisma.challenge.findFirst({
+    where: {
+      createdAt: { gt: challenge?.createdAt },
+    },
+    orderBy: { createdAt: 'asc'},
+    select: {
+      id: true,
+    }
+  })
+
+  return { challenge, nextChallengeId, prevChallengeId };
 };
 
 const getChallengeList = async ({

--- a/src/domains/challenges/challenges.type.ts
+++ b/src/domains/challenges/challenges.type.ts
@@ -1,4 +1,9 @@
-import { ApprovalStatus, Challenge, DocumentType, FieldType } from '@prisma/client';
+import {
+  ApprovalStatus,
+  Challenge,
+  DocumentType,
+  FieldType,
+} from '@prisma/client';
 
 export interface GetChallengeParam {
   challengeId: string;
@@ -22,6 +27,12 @@ export interface GetChallengeResponse {
   challenge: Challenge | null;
 }
 
+export interface GetChallengeResponseWithNextAndPrev {
+  challenge: Challenge | null;
+  prevChallengeId: { id: string } | null;
+  nextChallengeId: { id: string } | null;
+}
+
 export interface GetChallengeListByAdminResponse {
   challenges: {
     id: string;
@@ -33,7 +44,7 @@ export interface GetChallengeListByAdminResponse {
     createdAt: Date;
     documentType: DocumentType;
     approvalStatus: ApprovalStatus;
-  }[],
+  }[];
   totalCount: number;
 }
 
@@ -90,7 +101,6 @@ export interface GetChallengeListParticipating {
   userId: string;
   isExpired: string;
 }
-
 
 export enum Order {
   createdFirst = 'createdFirst',


### PR DESCRIPTION
## 📌 개요

- 관리자 챌린지 상세 페이지의 요구사항에 따라 추가적인 속성을 response에 담았습니다. (이전 챌린지, 다음 챌린지)

## ✨ 주요 변경 사항

- nextChallengeId, prevChallengeId 추가

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- nextChallengeId, prevChallengeId 추가 (로직에서 처리)

## 🔗 관련 이슈

- #100 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
