### PR TITLE
Feat/102 api admin challenge

### DIFF
--- a/src/domains/challenges/challenges.controller.ts
+++ b/src/domains/challenges/challenges.controller.ts
@@ -937,101 +937,6 @@ const patchChallenge: PatchController<
   }
 };
 
-/**
- * @swagger
- * /api/challenges/{challengeId}/removeForce:
- *   patch:
- *     tags:
- *       - Challenges
- *     summary: 관리자 전용 챌린지 삭제
- *     description: 챌린지 ID를 이용해 기존 챌린지를 삭제합니다.
- *     parameters:
- *       - in: path
- *         name: challengeId
- *         required: true
- *         description: 삭제할 챌린지의 ID
- *         schema:
- *           type: string
- *           example: "123e4567-e89b-12d3-a456-426614174000"
- *     responses:
- *       200:
- *         description: 챌린지가 성공적으로 삭제되었습니다.
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 code:
- *                   type: integer
- *                   description: 응답 코드
- *                   example: 200
- *       401:
- *         description: 로그인 정보 없음
- *       403:
- *         description: 권한 없음
- *       404:
- *         description: 삭제할 챌린지를 찾을 수 없음
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 code:
- *                   type: integer
- *                   description: 응답 코드
- *                   example: 404
- *                 message:
- *                   type: string
- *                   description: 에러 메시지
- *                   example: "챌린지를 찾을 수 없습니다."
- *       500:
- *         description: 서버 오류
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 code:
- *                   type: integer
- *                   description: 응답 코드
- *                   example: 500
- *                 message:
- *                   type: string
- *                   description: 에러 메시지
- *                   example: "서버 오류가 발생했습니다."
- */
-const deleteChallengeForce: DeleteController<
-  ChallengeRequestParams,
-  never,
-  DeleteChallengeResponse
-> = async (req, res, next) => {
-  try {
-    const id = req.params.challengeId;
-    const existChallenge = await ChallengesService.getChallenge(id);
-    const authRole = req.user?.role;
-    const deletedReason = req.body.deletedReason;
-    if (!existChallenge.challenge) {
-      next({ status: 404 });
-      return;
-    }
-    if (authRole !== 'ADMIN') {
-      next({ status: 403 });
-      return;
-    }
-    const result = await ChallengesService.deleteChallengeForce(
-      id,
-      deletedReason
-    );
-    if (!result) {
-      next({ statusCode: 404 });
-      return;
-    }
-    res.status(200).send({ code: 200 });
-  } catch (err) {
-    next(err);
-  }
-};
-
 
 /**
  * @swagger
@@ -1136,7 +1041,6 @@ const ChallengesController = {
   getChallenge,
   postChallenge,
   patchChallenge,
-  deleteChallengeForce,
   deleteChallenge,
 };
 

--- a/src/domains/challenges/challenges.routes.ts
+++ b/src/domains/challenges/challenges.routes.ts
@@ -51,18 +51,13 @@ router.patch(
   }),
   ChallengesController.patchChallenge
 ); //챌린지 수정
-router.patch(
-  '/:challengeId/removeForce',
-  verifyJWTToken,
-  validateRequestData({ params: ChallengeParamsSchema }),
-  ChallengesController.deleteChallengeForce
-); //챌린지 관리자 삭제
+
 router.patch(
   '/:challengeId/remove',
   verifyJWTToken,
   validateRequestData({ params: ChallengeParamsSchema }),
   ChallengesController.deleteChallenge
-); //챌린지 관리자 삭제
+); //챌린지 삭제
 router.get(
   '/:challengeId',
   verifyJWTToken,

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -30,9 +30,9 @@ const getChallenge = async (id: string): Promise<GetChallengeResponseWithNextAnd
 
   const prevChallengeId = await prisma.challenge.findFirst({
     where: {
-      createdAt: { lt: challenge?.createdAt},
+      idx: { lt: challenge?.idx},
     },
-    orderBy: { createdAt: 'desc' },
+    orderBy: { idx: 'desc' },
     select: {
       id: true,
     }
@@ -40,9 +40,9 @@ const getChallenge = async (id: string): Promise<GetChallengeResponseWithNextAnd
 
   const nextChallengeId = await prisma.challenge.findFirst({
     where: {
-      createdAt: { gt: challenge?.createdAt },
+      idx: { gt: challenge?.idx },
     },
-    orderBy: { createdAt: 'asc'},
+    orderBy: { idx: 'asc'},
     select: {
       id: true,
     }

--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -432,23 +432,6 @@ const updateChallenge = async ({
   return challenge;
 };
 
-const deleteChallengeForce = async (
-  id: string,
-  deletedReason: string
-): Promise<GetChallengeResponse> => {
-  const challenge = await prisma.challenge.update({
-    where: {
-      id,
-    },
-    data: {
-      deletedAt: new Date(),
-      deletedReason,
-      approvalStatus: 'DELETED',
-    },
-  });
-  return { challenge };
-};
-
 const deleteChallenge = async (id: string): Promise<GetChallengeResponse> => {
   const challenge = await prisma.challenge.update({
     where: {
@@ -470,7 +453,6 @@ const ChallengesService = {
   getChallenge,
   createChallenge,
   updateChallenge,
-  deleteChallengeForce,
   deleteChallenge,
 };
 

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -1,10 +1,14 @@
-import { PatchController } from '../../types/express';
+import { DeleteController, PatchController } from '../../types/express';
 import {
   ChallengeAdminParams,
   ChallengeAdminRejectBody,
 } from './challenges.admin.validation';
 import ChallengesAdminService from './challenges.admin.service';
 import { ChallengeAdminResponse } from './challenges.admin.type';
+import { ChallengeRequestParams } from '../challenges/challenges.validation';
+import { DeleteChallengeResponse } from '../challenges/challenges.type';
+import ChallengesService from '../challenges/challenges.service';
+import challengesAdminService from './challenges.admin.service';
 
 /**
  * @swagger
@@ -324,7 +328,104 @@ const patchChallengeReject: PatchController<
   return;
 };
 
+
+/**
+ * @swagger
+ * /api/challenges/{challengeId}/admin/removeForce:
+ *   patch:
+ *     tags:
+ *       - Challenges
+ *     summary: 관리자 전용 챌린지 삭제
+ *     description: 챌린지 ID를 이용해 기존 챌린지를 삭제합니다.
+ *     parameters:
+ *       - in: path
+ *         name: challengeId
+ *         required: true
+ *         description: 삭제할 챌린지의 ID
+ *         schema:
+ *           type: string
+ *           example: "123e4567-e89b-12d3-a456-426614174000"
+ *     responses:
+ *       200:
+ *         description: 챌린지가 성공적으로 삭제되었습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   description: 응답 코드
+ *                   example: 200
+ *       401:
+ *         description: 로그인 정보 없음
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 삭제할 챌린지를 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   description: 응답 코드
+ *                   example: 404
+ *                 message:
+ *                   type: string
+ *                   description: 에러 메시지
+ *                   example: "챌린지를 찾을 수 없습니다."
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: integer
+ *                   description: 응답 코드
+ *                   example: 500
+ *                 message:
+ *                   type: string
+ *                   description: 에러 메시지
+ *                   example: "서버 오류가 발생했습니다."
+ */
+const deleteChallengeForce: DeleteController<
+  ChallengeRequestParams,
+  never,
+  DeleteChallengeResponse
+> = async (req, res, next) => {
+  try {
+    const id = req.params.challengeId;
+    const existChallenge = await ChallengesService.getChallenge(id);
+    const authRole = req.user?.role;
+    const deletedReason = req.body.deletedReason;
+    if (!existChallenge.challenge) {
+      next({ status: 404 });
+      return;
+    }
+    if (authRole !== 'ADMIN') {
+      next({ status: 403 });
+      return;
+    }
+    const result = await ChallengesAdminService.deleteChallengeForce(
+      id,
+      deletedReason
+    );
+    if (!result) {
+      next({ statusCode: 404 });
+      return;
+    }
+    res.status(200).send({ code: 200 });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export default {
   patchChallengeApprove,
   patchChallengeReject,
+  deleteChallengeForce,
 };

--- a/src/domains/challenges_admin/challenges.admin.controller.ts
+++ b/src/domains/challenges_admin/challenges.admin.controller.ts
@@ -5,8 +5,14 @@ import {
 } from './challenges.admin.validation';
 import ChallengesAdminService from './challenges.admin.service';
 import { ChallengeAdminResponse } from './challenges.admin.type';
-import { ChallengeRequestParams } from '../challenges/challenges.validation';
-import { DeleteChallengeResponse } from '../challenges/challenges.type';
+import {
+  ChallengeRequestBody,
+  ChallengeRequestParams,
+} from '../challenges/challenges.validation';
+import {
+  DeleteChallengeResponse,
+  UpdateChallengeResponse,
+} from '../challenges/challenges.type';
 import ChallengesService from '../challenges/challenges.service';
 import challengesAdminService from './challenges.admin.service';
 
@@ -328,13 +334,12 @@ const patchChallengeReject: PatchController<
   return;
 };
 
-
 /**
  * @swagger
  * /api/challenges/{challengeId}/admin/removeForce:
  *   patch:
  *     tags:
- *       - Challenges
+ *       - Challenges Admin
  *     summary: 관리자 전용 챌린지 삭제
  *     description: 챌린지 ID를 이용해 기존 챌린지를 삭제합니다.
  *     parameters:
@@ -424,8 +429,167 @@ const deleteChallengeForce: DeleteController<
   }
 };
 
+/**
+ * @swagger
+ * /api/challenges/{challengeId}/admin/modify:
+ *   patch:
+ *     tags:
+ *       - Challenges Admin
+ *     summary: 관리자 전용 챌린지 수정
+ *     description: 챌린지 ID를 이용해 기존 챌린지 정보를 수정합니다.
+ *     parameters:
+ *       - in: path
+ *         name: challengeId
+ *         required: true
+ *         description: 수정할 챌린지의 ID
+ *         schema:
+ *           type: string
+ *           example: "123e4567-e89b-12d3-a456-426614174000"
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 description: 챌린지 제목
+ *                 example: "수정된 프론트엔드 번역 챌린지"
+ *               description:
+ *                 type: string
+ *                 description: 챌린지 설명
+ *                 example: "수정된 프론트엔드 관련 문서를 번역하는 챌린지입니다."
+ *               documentType:
+ *                 type: string
+ *                 description: 문서 타입
+ *                 enum: [BLOG, OFFICIAL]
+ *                 example: "BLOG"
+ *               field:
+ *                 type: string
+ *                 description: 챌린지 분야
+ *                 enum: [NEXTJS, MODERNJS, API, WEB, CAREER]
+ *                 example: "NEXTJS"
+ *               maxParticipants:
+ *                 type: integer
+ *                 description: 최대 참가자 수
+ *                 example: 15
+ *               deadline:
+ *                 type: string
+ *                 format: date-time
+ *                 description: 챌린지 마감일
+ *                 example: "2025-05-01T00:00:00.000Z"
+ *               originURL:
+ *                 type: string
+ *                 format: url
+ *                 description: 원본 문서 URL
+ *                 example: "https://example.com/updated-doc"
+ *     responses:
+ *       200:
+ *         description: 챌린지가 성공적으로 수정되었습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 challenge:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       description: 챌린지 ID
+ *                       example: "123e4567-e89b-12d3-a456-426614174000"
+ *                     title:
+ *                       type: string
+ *                       description: 챌린지 제목
+ *                       example: "수정된 프론트엔드 번역 챌린지"
+ *                     description:
+ *                       type: string
+ *                       description: 챌린지 설명
+ *                       example: "수정된 프론트엔드 관련 문서를 번역하는 챌린지입니다."
+ *                     documentType:
+ *                       type: string
+ *                       description: 문서 타입
+ *                       example: "BLOG"
+ *                     field:
+ *                       type: string
+ *                       description: 챌린지 분야
+ *                       example: "NEXTJS"
+ *                     maxParticipants:
+ *                       type: integer
+ *                       description: 최대 참가자 수
+ *                       example: 15
+ *                     deadline:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 챌린지 마감일
+ *                       example: "2025-05-01T00:00:00.000Z"
+ *                     originURL:
+ *                       type: string
+ *                       format: url
+ *                       description: 원본 문서 URL
+ *                       example: "https://example.com/updated-doc"
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 마지막 업데이트 날짜
+ *                       example: "2025-03-30T12:00:00.000Z"
+ *       400:
+ *         description: 잘못된 요청 데이터
+ *       401:
+ *         description: 로그인 정보 없음
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 챌린지를 찾을 수 없음
+ *       500:
+ *         description: 서버 오류
+ */
+const patchChallengeForce: PatchController<
+  ChallengeRequestParams,
+  ChallengeRequestBody,
+  UpdateChallengeResponse
+> = async (req, res, next) => {
+  try {
+    const id = req.params.challengeId;
+    const authRole = req.user?.role;
+    if (authRole !== 'ADMIN') {
+      next({ status: 403 });
+      return;
+    }
+    const existChallenge = await ChallengesService.getChallenge(id);
+    if (!existChallenge.challenge) {
+      next({ status: 404 });
+      return;
+    }
+    const {
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+    } = req.body;
+    const result = await ChallengesAdminService.updateChallengeForce({
+      id,
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+    });
+    res.status(200).send({ challenge: result, code: 200 });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export default {
   patchChallengeApprove,
   patchChallengeReject,
   deleteChallengeForce,
+  patchChallengeForce,
 };

--- a/src/domains/challenges_admin/challenges.admin.routes.ts
+++ b/src/domains/challenges_admin/challenges.admin.routes.ts
@@ -6,7 +6,10 @@ import {
   ChallengeAdminParamsSchema,
   ChallengeAdminRejectBodySchema,
 } from './challenges.admin.validation';
-import { ChallengeParamsSchema } from '../challenges/challenges.validation';
+import {
+  ChallengeBodySchema,
+  ChallengeParamsSchema,
+} from '../challenges/challenges.validation';
 const router = Router({ mergeParams: true });
 
 router.use(verifyJWTToken);
@@ -28,6 +31,13 @@ router.patch(
   }),
   ChallengesAdminController.patchChallengeReject
 ); //챌린지 거절
-router.patch('/remove'); //챌린지 삭제
+router.patch(
+  '/modify',
+  validateRequestData({
+    params: ChallengeParamsSchema,
+    body: ChallengeBodySchema,
+  }),
+  ChallengesAdminController.patchChallengeForce
+);
 
 export default router;

--- a/src/domains/challenges_admin/challenges.admin.routes.ts
+++ b/src/domains/challenges_admin/challenges.admin.routes.ts
@@ -6,10 +6,15 @@ import {
   ChallengeAdminParamsSchema,
   ChallengeAdminRejectBodySchema,
 } from './challenges.admin.validation';
+import { ChallengeParamsSchema } from '../challenges/challenges.validation';
 const router = Router({ mergeParams: true });
 
 router.use(verifyJWTToken);
-
+router.patch(
+  '/removeForce',
+  validateRequestData({ params: ChallengeParamsSchema }),
+  ChallengesAdminController.deleteChallengeForce
+); //챌린지 관리자 삭제
 router.patch(
   '/approve',
   validateRequestData({ params: ChallengeAdminParamsSchema }),

--- a/src/domains/challenges_admin/challenges.admin.service.ts
+++ b/src/domains/challenges_admin/challenges.admin.service.ts
@@ -1,4 +1,5 @@
 import prisma from '../../prismaClient';
+import { GetChallengeResponse } from '../challenges/challenges.type';
 
 const checkChallenge = async (id: string) => {
   const challenge = await prisma.challenge.findUnique({
@@ -33,8 +34,28 @@ const rejectChallenge = async (id: string, rejectedReason: string) => {
   });
   return updateChallenge;
 };
+
+
+const deleteChallengeForce = async (
+  id: string,
+  deletedReason: string
+): Promise<GetChallengeResponse> => {
+  const challenge = await prisma.challenge.update({
+    where: {
+      id,
+    },
+    data: {
+      deletedAt: new Date(),
+      deletedReason,
+      approvalStatus: 'DELETED',
+    },
+  });
+  return { challenge };
+};
+
 export default {
   checkChallenge,
   approveChallenge,
   rejectChallenge,
+  deleteChallengeForce,
 };

--- a/src/domains/challenges_admin/challenges.admin.service.ts
+++ b/src/domains/challenges_admin/challenges.admin.service.ts
@@ -1,5 +1,8 @@
 import prisma from '../../prismaClient';
-import { GetChallengeResponse } from '../challenges/challenges.type';
+import {
+  GetChallengeResponse,
+  UpdateChallengeArgs,
+} from '../challenges/challenges.type';
 
 const checkChallenge = async (id: string) => {
   const challenge = await prisma.challenge.findUnique({
@@ -35,7 +38,6 @@ const rejectChallenge = async (id: string, rejectedReason: string) => {
   return updateChallenge;
 };
 
-
 const deleteChallengeForce = async (
   id: string,
   deletedReason: string
@@ -53,9 +55,38 @@ const deleteChallengeForce = async (
   return { challenge };
 };
 
+const updateChallengeForce = async ({
+  id,
+  title,
+  description,
+  documentType,
+  field,
+  maxParticipants,
+  deadline,
+  originURL,
+}: UpdateChallengeArgs) => {
+  const challenge = await prisma.challenge.update({
+    where: {
+      id,
+    },
+    data: {
+      title,
+      description,
+      documentType,
+      field,
+      maxParticipants,
+      deadline,
+      originURL,
+    },
+  });
+
+  return challenge;
+};
+
 export default {
   checkChallenge,
   approveChallenge,
   rejectChallenge,
   deleteChallengeForce,
+  updateChallengeForce,
 };


### PR DESCRIPTION
## 📌 개요

- 관리자 전용 챌린지 수정 추가, 관리자 전용 챌린지 삭제 라우팅 변경

## ✨ 주요 변경 사항

- 관리자 전용 챌린지 삭제의 url이 변동되었습니다.
- 관리자 전용 챌린지 수정이 추가되었습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 변동사항을 swagger에 반영 하였습니다.

## 🔗 관련 이슈

- #102 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
