### PR TITLE
fix: 사용자 챌린지 삭제api, 삭제 사유 추가

### DIFF
--- a/src/domains/challenges/challenges.service.ts
+++ b/src/domains/challenges/challenges.service.ts
@@ -32,11 +32,7 @@ const getChallenge = async (
 
   const prevChallengeId = await prisma.challenge.findFirst({
     where: {
-
-   
-
-      idx: { lt: challenge?.idx},
-
+      idx: { lt: challenge?.idx },
     },
     orderBy: { idx: 'desc' },
     select: {
@@ -49,8 +45,7 @@ const getChallenge = async (
       idx: { gt: challenge?.idx },
     },
 
-
-    orderBy: { idx: 'asc'},
+    orderBy: { idx: 'asc' },
 
     select: {
       id: true,
@@ -449,6 +444,7 @@ const deleteChallenge = async (id: string): Promise<GetChallengeResponse> => {
     data: {
       deletedAt: new Date(),
       approvalStatus: 'DELETED',
+      deletedReason: '작성자에 의해 삭제되었습니다.',
     },
   });
   return { challenge };


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 승인 대기인 상태의 챌린지를 사용자가 삭제 했을 때 `작성자에 의해 삭제되었습니다.` 라는 삭제 사유가 디비에 추가됩니다.

## 이슈
https://www.notion.so/api-1d236713bdaf800aa030e2618915eb29?pvs=4