### PR TITLE
[Feat] 번역물 생성 수정시 내용 글자 수 파싱 적용

### DIFF
--- a/src/domains/translations/translations.routes.ts
+++ b/src/domains/translations/translations.routes.ts
@@ -63,8 +63,8 @@ router.delete(
   TranslationsController.deleteTranslation as unknown as RequestHandler
 );
 
-router.post('/draftedTranslations'); // 작업물 임시 저장
-router.get('/draftedTranslations'); // 작업물 임시 저장 가져오기
+// router.post('/draftedTranslations'); // 작업물 임시 저장
+// router.get('/draftedTranslations'); // 작업물 임시 저장 가져오기
 // router.use('/:translationId/feedbacks', FeedbackRouter);
 
 export default router;

--- a/src/domains/translations/translations.types.ts
+++ b/src/domains/translations/translations.types.ts
@@ -52,12 +52,16 @@ export const TranslationRequestBody = z.object({
         // console.log('원본 길이:', val.length);
         // console.log('HTML 제거 후 길이:', cleanContent.length);
         // console.log('콘텐츠 내용:', cleanContent);
-
+        // if (cleanContent.length > 2000) {
+        //   console.warn(
+        //     ` 내용 길이 제한 초과: ${cleanContent.length}자 (최대 2000자)`
+        //   );
+        // }
         // 정제된 콘텐츠 길이 검증
-        return cleanContent.length >= 1 && cleanContent.length <= 1000;
+        return cleanContent.length >= 1 && cleanContent.length <= 2000;
       },
       {
-        message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
+        message: '내용은 최소 1자 이상 최대 2000자 이하로 입력해주세요.',
       }
     ),
 });
@@ -86,10 +90,10 @@ export const TranslationUpdateBodySchema = z.object({
         // console.log('수정 요청 - 콘텐츠 내용:', cleanContent);
 
         // 정제된 콘텐츠 길이 검증
-        return cleanContent.length >= 1 && cleanContent.length <= 1000;
+        return cleanContent.length >= 1 && cleanContent.length <= 2000;
       },
       {
-        message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
+        message: '내용은 최소 1자 이상 최대 2000자 이하로 입력해주세요.',
       }
     ),
 });

--- a/src/domains/translations/translations.types.ts
+++ b/src/domains/translations/translations.types.ts
@@ -43,9 +43,23 @@ export const TranslationRequestBody = z.object({
   content: z
     .string()
     .trim()
-    .refine((val) => val.length >= 1 && val.length <= 1000, {
-      message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
-    }),
+    .refine(
+      (val) => {
+        // HTML 태그 제거
+        const strippedContent = val.replace(/<[^>]*>/g, '');
+        const cleanContent = strippedContent.replace(/\s+/g, ' ').trim();
+
+        // console.log('원본 길이:', val.length);
+        // console.log('HTML 제거 후 길이:', cleanContent.length);
+        // console.log('콘텐츠 내용:', cleanContent);
+
+        // 정제된 콘텐츠 길이 검증
+        return cleanContent.length >= 1 && cleanContent.length <= 1000;
+      },
+      {
+        message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
+      }
+    ),
 });
 
 export type TranslationRequestBody = z.infer<typeof TranslationRequestBody>;
@@ -61,9 +75,23 @@ export const TranslationUpdateBodySchema = z.object({
   content: z
     .string()
     .trim()
-    .refine((val) => val.length >= 1 && val.length <= 1000, {
-      message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
-    }),
+    .refine(
+      (val) => {
+        // HTML 태그 제거
+        const strippedContent = val.replace(/<[^>]*>/g, '');
+        const cleanContent = strippedContent.replace(/\s+/g, ' ').trim();
+
+        // console.log('수정 요청 - 원본 길이:', val.length);
+        // console.log('수정 요청 - HTML 제거 후 길이:', cleanContent.length);
+        // console.log('수정 요청 - 콘텐츠 내용:', cleanContent);
+
+        // 정제된 콘텐츠 길이 검증
+        return cleanContent.length >= 1 && cleanContent.length <= 1000;
+      },
+      {
+        message: '내용은 최소 1자 이상 최대 1000자 이하로 입력해주세요.',
+      }
+    ),
 });
 
 // 번역물 수정 요청 바디 타입

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -17,7 +17,7 @@ const createToken = (
     tokenType,
   };
 
-  const expiresIn = tokenType === 'access' ? '10m' : '1d';
+  const expiresIn = tokenType === 'access' ? '1m' : '1d';
   const secret =
     tokenType === 'access'
       ? process.env.JWT_ACCESS_SECRET || 'access-secret'
@@ -44,7 +44,7 @@ const verifyToken = (
       tokenType === 'access'
         ? process.env.JWT_ACCESS_SECRET || 'access-secret'
         : process.env.JWT_REFRESH_SECRET || 'refresh-secret';
-    // console.log('🔍 token:', token);
+    console.log('🔍 token:', token);
     // console.log('🔍 tokenType:', tokenType);
     // console.log('🔍 secret:', secret);
 


### PR DESCRIPTION
## 📌 개요

- 번역물 생성, 수정시 content 의 입력 길이 제한이 1000자로 설정되어 있는데 , html 태그로 인해 글자 수가 불어나서 내용을 조금만 적어도 입력 길이 제한 에러가 발생하는 버그 발생 

## ✨ 주요 변경 사항

- html태그를 제거한 후 순수 텍스트 길이를 검증하도록 수정하였습니다. 
- 글자 수 제한 2000자로 수정했습니다. 

## 🔗 관련 이슈

- #117 

## 📸 스크린샷
<img width="913" alt="image" src="https://github.com/user-attachments/assets/c1e209a9-d335-411d-897a-25223e8b8355" />
<img width="644" alt="image" src="https://github.com/user-attachments/assets/8e399265-14f9-4d08-9a83-20b9858ab85e" />

