### PR TITLE
Fix/119 챌린지 글자 수 제한 변경(30자) 및 번역물 생성 시 에러 메시지 줄바꿈 적용

### DIFF
--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -184,12 +184,14 @@ const login = async (req: Request, res: Response, next: NextFunction) => {
       httpOnly: false,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
       sameSite: 'none',
       secure: true,
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
 
     const { password: p, refreshToken: r, ...restUser } = existedUser;
@@ -258,6 +260,7 @@ const logout = async (req: Request, res: Response, next: NextFunction) => {
       httpOnly: true,
       sameSite: 'none',
       secure: true,
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
 
     // accessToken도 제거
@@ -265,6 +268,7 @@ const logout = async (req: Request, res: Response, next: NextFunction) => {
       httpOnly: false,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
     res.status(200).json({ message: '로그아웃 완료' });
   } catch (err) {

--- a/src/domains/challenges/challenges.validation.ts
+++ b/src/domains/challenges/challenges.validation.ts
@@ -30,7 +30,7 @@ export const ChallengeQueriesSchema = z.object({
 });
 
 export const ChallengeBodySchema = z.object({
-  title: z.string().min(2, "제목은 최소 2자 이상이어야 합니다.").max(15, "제목은 최대 15자까지 입력할 수 있습니다."),
+  title: z.string().min(2, "제목은 최소 2자 이상이어야 합니다.").max(30, "제목은 최대 30자까지 입력할 수 있습니다."),
   description: z.string().min(10, "설명은 최소 10자 이상이어야 합니다.").max(100, "설명은 최대 100자 이상이어야 합니다."),
   documentType: z.nativeEnum(DocumentType, { errorMap: () => ({ message: "잘못된 문서 유형입니다."})}),
   field: z.nativeEnum(FieldType, { errorMap: () => ({ message: "잘못된 카테고리 유형입니다."})}),

--- a/src/domains/translations/translations.service.ts
+++ b/src/domains/translations/translations.service.ts
@@ -216,7 +216,7 @@ const createTranslation = async ({
 
     if (existingTranslation) {
       throw new Error(
-        '이미 이 챌린지에 번역물을 제출하셨습니다. 한 챌린지당 하나의 번역물만 제출할 수 있습니다.'
+        '이미 이 챌린지에 번역물을 제출하셨습니다.\n한 챌린지당 하나의 번역물만 제출할 수 있습니다.'
       );
     }
 

--- a/src/middleware/verifyJWTToken.ts
+++ b/src/middleware/verifyJWTToken.ts
@@ -89,12 +89,14 @@ export const verifyJWTToken = async (
       httpOnly: false, // 프론트엔드에서 접근 가능하게 false
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
 
     res.cookie('refreshToken', newRefreshToken, {
       httpOnly: true, // JS에서 접근 불가
       sameSite: 'none',
       secure: true,
+      domain: 'https://doc-thru-fe.vercel.app/'
     });
 
     req.user = newUserInfo;


### PR DESCRIPTION
## 📌 개요

- 챌린지 글자 수 제한 변경(30자) 및 번역물 생성 시 에러 메시지 줄바꿈 적용

## ✨ 주요 변경 사항

- 챌린지 제목 수 30자로 변경되었습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- #119 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
